### PR TITLE
:bug: Fixing bug where the data was cached while creating a scene :bug:

### DIFF
--- a/client/src/builder/components/editors/scene-editor.tsx
+++ b/client/src/builder/components/editors/scene-editor.tsx
@@ -72,7 +72,7 @@ export const SceneEditor = ({
 }: SceneEditorProps) => {
   const form = useForm<SceneEditorSchema>({
     resolver: zodResolver(schema),
-    defaultValues: defaultValues ?? { actions: [] },
+    defaultValues: defaultValues ?? { title: "", content: "", actions: [] },
   });
 
   const { fields, append, remove } = useFieldArray({
@@ -84,6 +84,13 @@ export const SceneEditor = ({
 
   const isOpen = open !== undefined ? open : internalOpen;
   const handleOpen = setOpen !== undefined ? setOpen : setInternalOpen;
+
+  // Reset form to empty values when opening for new scene creation
+  useEffect(() => {
+    if (isOpen && !defaultValues) {
+      form.reset({ title: "", content: "", actions: [] });
+    }
+  }, [isOpen, defaultValues, form]);
 
   useEffect(() => {
     // Update the form when the default values change, which are 'cached' otherwise
@@ -101,15 +108,7 @@ export const SceneEditor = ({
   );
 
   return (
-    <Dialog
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          form.reset();
-        }
-        handleOpen(open);
-      }}
-    >
+    <Dialog open={isOpen} onOpenChange={handleOpen}>
       {!!trigger && (
         <DialogTrigger
           className={cn("cursor-pointer", triggerClassName)}

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -8,56 +8,132 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as AboutRouteImport } from './routes/about'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as LibraryIndexRouteImport } from './routes/library/index'
-import { Route as LibraryStoryKeyRouteImport } from './routes/library/$storyKey'
-import { Route as BuilderStoriesRouteImport } from './routes/builder/stories'
-import { Route as BuilderStoryKeyRouteImport } from './routes/builder/$storyKey'
-import { Route as GameGameKeySceneKeyRouteImport } from './routes/game/$gameKey/$sceneKey'
-import { Route as GameTestGameKeySceneKeyRouteImport } from './routes/game/test/$gameKey/$sceneKey'
+// Import Routes
 
-const AboutRoute = AboutRouteImport.update({
+import { Route as rootRoute } from './routes/__root'
+import { Route as AboutImport } from './routes/about'
+import { Route as IndexImport } from './routes/index'
+import { Route as LibraryIndexImport } from './routes/library/index'
+import { Route as LibraryStoryKeyImport } from './routes/library/$storyKey'
+import { Route as BuilderStoriesImport } from './routes/builder/stories'
+import { Route as BuilderStoryKeyImport } from './routes/builder/$storyKey'
+import { Route as GameGameKeySceneKeyImport } from './routes/game/$gameKey/$sceneKey'
+import { Route as GameTestGameKeySceneKeyImport } from './routes/game/test/$gameKey/$sceneKey'
+
+// Create/Update Routes
+
+const AboutRoute = AboutImport.update({
   id: '/about',
   path: '/about',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const IndexRoute = IndexRouteImport.update({
+
+const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LibraryIndexRoute = LibraryIndexRouteImport.update({
+
+const LibraryIndexRoute = LibraryIndexImport.update({
   id: '/library/',
   path: '/library/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const LibraryStoryKeyRoute = LibraryStoryKeyRouteImport.update({
+
+const LibraryStoryKeyRoute = LibraryStoryKeyImport.update({
   id: '/library/$storyKey',
   path: '/library/$storyKey',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const BuilderStoriesRoute = BuilderStoriesRouteImport.update({
+
+const BuilderStoriesRoute = BuilderStoriesImport.update({
   id: '/builder/stories',
   path: '/builder/stories',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const BuilderStoryKeyRoute = BuilderStoryKeyRouteImport.update({
+
+const BuilderStoryKeyRoute = BuilderStoryKeyImport.update({
   id: '/builder/$storyKey',
   path: '/builder/$storyKey',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const GameGameKeySceneKeyRoute = GameGameKeySceneKeyRouteImport.update({
+
+const GameGameKeySceneKeyRoute = GameGameKeySceneKeyImport.update({
   id: '/game/$gameKey/$sceneKey',
   path: '/game/$gameKey/$sceneKey',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
-const GameTestGameKeySceneKeyRoute = GameTestGameKeySceneKeyRouteImport.update({
+
+const GameTestGameKeySceneKeyRoute = GameTestGameKeySceneKeyImport.update({
   id: '/game/test/$gameKey/$sceneKey',
   path: '/game/test/$gameKey/$sceneKey',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => rootRoute,
 } as any)
+
+// Populate the FileRoutesByPath interface
+
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutImport
+      parentRoute: typeof rootRoute
+    }
+    '/builder/$storyKey': {
+      id: '/builder/$storyKey'
+      path: '/builder/$storyKey'
+      fullPath: '/builder/$storyKey'
+      preLoaderRoute: typeof BuilderStoryKeyImport
+      parentRoute: typeof rootRoute
+    }
+    '/builder/stories': {
+      id: '/builder/stories'
+      path: '/builder/stories'
+      fullPath: '/builder/stories'
+      preLoaderRoute: typeof BuilderStoriesImport
+      parentRoute: typeof rootRoute
+    }
+    '/library/$storyKey': {
+      id: '/library/$storyKey'
+      path: '/library/$storyKey'
+      fullPath: '/library/$storyKey'
+      preLoaderRoute: typeof LibraryStoryKeyImport
+      parentRoute: typeof rootRoute
+    }
+    '/library/': {
+      id: '/library/'
+      path: '/library'
+      fullPath: '/library'
+      preLoaderRoute: typeof LibraryIndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/game/$gameKey/$sceneKey': {
+      id: '/game/$gameKey/$sceneKey'
+      path: '/game/$gameKey/$sceneKey'
+      fullPath: '/game/$gameKey/$sceneKey'
+      preLoaderRoute: typeof GameGameKeySceneKeyImport
+      parentRoute: typeof rootRoute
+    }
+    '/game/test/$gameKey/$sceneKey': {
+      id: '/game/test/$gameKey/$sceneKey'
+      path: '/game/test/$gameKey/$sceneKey'
+      fullPath: '/game/test/$gameKey/$sceneKey'
+      preLoaderRoute: typeof GameTestGameKeySceneKeyImport
+      parentRoute: typeof rootRoute
+    }
+  }
+}
+
+// Create and export the route tree
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -69,6 +145,7 @@ export interface FileRoutesByFullPath {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
+
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
@@ -79,8 +156,9 @@ export interface FileRoutesByTo {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
+
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
+  __root__: typeof rootRoute
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/builder/$storyKey': typeof BuilderStoryKeyRoute
@@ -90,6 +168,7 @@ export interface FileRoutesById {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
+
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
@@ -123,6 +202,7 @@ export interface FileRouteTypes {
     | '/game/test/$gameKey/$sceneKey'
   fileRoutesById: FileRoutesById
 }
+
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
@@ -132,67 +212,6 @@ export interface RootRouteChildren {
   LibraryIndexRoute: typeof LibraryIndexRoute
   GameGameKeySceneKeyRoute: typeof GameGameKeySceneKeyRoute
   GameTestGameKeySceneKeyRoute: typeof GameTestGameKeySceneKeyRoute
-}
-
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/library/': {
-      id: '/library/'
-      path: '/library'
-      fullPath: '/library'
-      preLoaderRoute: typeof LibraryIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/library/$storyKey': {
-      id: '/library/$storyKey'
-      path: '/library/$storyKey'
-      fullPath: '/library/$storyKey'
-      preLoaderRoute: typeof LibraryStoryKeyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/builder/stories': {
-      id: '/builder/stories'
-      path: '/builder/stories'
-      fullPath: '/builder/stories'
-      preLoaderRoute: typeof BuilderStoriesRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/builder/$storyKey': {
-      id: '/builder/$storyKey'
-      path: '/builder/$storyKey'
-      fullPath: '/builder/$storyKey'
-      preLoaderRoute: typeof BuilderStoryKeyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/game/$gameKey/$sceneKey': {
-      id: '/game/$gameKey/$sceneKey'
-      path: '/game/$gameKey/$sceneKey'
-      fullPath: '/game/$gameKey/$sceneKey'
-      preLoaderRoute: typeof GameGameKeySceneKeyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/game/test/$gameKey/$sceneKey': {
-      id: '/game/test/$gameKey/$sceneKey'
-      path: '/game/test/$gameKey/$sceneKey'
-      fullPath: '/game/test/$gameKey/$sceneKey'
-      preLoaderRoute: typeof GameTestGameKeySceneKeyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -205,6 +224,51 @@ const rootRouteChildren: RootRouteChildren = {
   GameGameKeySceneKeyRoute: GameGameKeySceneKeyRoute,
   GameTestGameKeySceneKeyRoute: GameTestGameKeySceneKeyRoute,
 }
-export const routeTree = rootRouteImport
+
+export const routeTree = rootRoute
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+/* ROUTE_MANIFEST_START
+{
+  "routes": {
+    "__root__": {
+      "filePath": "__root.tsx",
+      "children": [
+        "/",
+        "/about",
+        "/builder/$storyKey",
+        "/builder/stories",
+        "/library/$storyKey",
+        "/library/",
+        "/game/$gameKey/$sceneKey",
+        "/game/test/$gameKey/$sceneKey"
+      ]
+    },
+    "/": {
+      "filePath": "index.tsx"
+    },
+    "/about": {
+      "filePath": "about.tsx"
+    },
+    "/builder/$storyKey": {
+      "filePath": "builder/$storyKey.tsx"
+    },
+    "/builder/stories": {
+      "filePath": "builder/stories.tsx"
+    },
+    "/library/$storyKey": {
+      "filePath": "library/$storyKey.tsx"
+    },
+    "/library/": {
+      "filePath": "library/index.tsx"
+    },
+    "/game/$gameKey/$sceneKey": {
+      "filePath": "game/$gameKey/$sceneKey.tsx"
+    },
+    "/game/test/$gameKey/$sceneKey": {
+      "filePath": "game/test/$gameKey/$sceneKey.tsx"
+    }
+  }
+}
+ROUTE_MANIFEST_END */


### PR DESCRIPTION
Cause :
React Hook Form gardait en cache les valeurs précédemment saisies. La logique de reset existante n'était pas suffisante pour vider le formulaire lors de l'ouverture pour une nouvelle création de scène.

Solution
Ajout d'un [useEffect] ciblé qui remet à zéro le formulaire avec des valeurs vides lors de l'ouverture du modal spécifiquement pour la création d'une nouvelle scène (quand [defaultValues] est undefined).

Attention, le fichier routeTree.gen.ts a été modifié tout seul et je n'ai pas tout compris :)