### PR TITLE
Fix Synchronization bug - Local database is not properly cleared when loading cloud data

### DIFF
--- a/client/src/domains/__tests__/game-service.test.ts
+++ b/client/src/domains/__tests__/game-service.test.ts
@@ -166,25 +166,5 @@ describe("game-service", () => {
 
       expect(p).toStrictEqual([BASIC_STORY_PROGRESS]);
     });
-
-    describe("loadGamesState", () => {
-      it("should load state in the local database", async () => {
-        await gameService.loadGamesState({
-          progresses: [BASIC_STORY_PROGRESS],
-          libraryStories: { stories: [BASIC_STORY], scenes: [BASIC_SCENE] },
-        });
-
-        expect(localRepository.unitOfWork).toHaveBeenCalled();
-        expect(
-          localRepository.updateOrCreateStoryProgresses,
-        ).toHaveBeenCalledWith([BASIC_STORY_PROGRESS]);
-        expect(localRepository.updateOrCreateStories).toHaveBeenCalledWith([
-          BASIC_STORY,
-        ]);
-        expect(localRepository.updateOrCreateScenes).toHaveBeenCalledWith([
-          BASIC_SCENE,
-        ]);
-      });
-    });
   });
 });

--- a/client/src/domains/__tests__/library-service.test.ts
+++ b/client/src/domains/__tests__/library-service.test.ts
@@ -212,4 +212,24 @@ describe("library-service", () => {
       expect(localRepository.deleteScenes).toHaveBeenCalledOnce();
     });
   });
+
+  describe("loadLibraryState", () => {
+    it("should load state in the local database", async () => {
+      await libraryService.loadLibraryState({
+        progresses: [BASIC_STORY_PROGRESS],
+        libraryStories: { stories: [BASIC_STORY], scenes: [BASIC_SCENE] },
+      });
+
+      expect(localRepository.unitOfWork).toHaveBeenCalled();
+      expect(
+        localRepository.updateOrCreateStoryProgresses,
+      ).toHaveBeenCalledWith([BASIC_STORY_PROGRESS]);
+      expect(localRepository.updateOrCreateStories).toHaveBeenCalledWith([
+        BASIC_STORY,
+      ]);
+      expect(localRepository.updateOrCreateScenes).toHaveBeenCalledWith([
+        BASIC_SCENE,
+      ]);
+    });
+  });
 });

--- a/client/src/domains/builder/builder-service.ts
+++ b/client/src/domains/builder/builder-service.ts
@@ -41,6 +41,15 @@ export const _getBuilderService = ({
     return { story, scenes };
   };
 
+  const getAllBuilderData = async () => {
+    const stories = await getUserBuilderStories();
+    const scenes = await localRepository.getScenesByStoryKey(
+      stories?.map((story) => story.key) ?? [],
+    );
+
+    return { stories, scenes };
+  };
+
   return {
     updateSceneBuilderPosition: async (
       sceneKey: string,
@@ -193,27 +202,33 @@ export const _getBuilderService = ({
     },
 
     getBuilderStoryData,
-
     getUserBuilderStories,
-
-    getAllBuilderData: async () => {
-      const stories = await getUserBuilderStories();
-      const scenes = await localRepository.getScenesByStoryKey(
-        stories?.map((story) => story.key) ?? [],
-      );
-
-      return { stories, scenes };
-    },
+    getAllBuilderData,
 
     loadBuilderState: async (stories: Story[], scenes: Scene[]) => {
+      const newScenesKeys = scenes.map((s) => s.key);
+      const newStoriesKeys = stories.map((s) => s.key);
       await localRepository.unitOfWork(
         async () => {
+          const currentState = await getAllBuilderData();
+          // Delete scenes that don't exist anymore
+          await localRepository.deleteScenes(
+            currentState.scenes
+              .filter((s) => !newScenesKeys.includes(s.key))
+              .map((s) => s.key),
+          );
+          // Delete stories that don't exist anymore
+          await localRepository.deleteStories(
+            currentState.stories
+              .filter((s) => !newStoriesKeys.includes(s.key))
+              .map((s) => s.key),
+          );
           await localRepository.updateOrCreateStories(stories);
           await localRepository.updateOrCreateScenes(scenes);
         },
         {
           mode: "readwrite",
-          entities: ["scene", "story"],
+          entities: ["scene", "story", "user"],
         },
       );
     },

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -1,4 +1,4 @@
-import { Action, Scene, Story, StoryProgress } from "@/lib/storage/domain";
+import { Action, StoryProgress } from "@/lib/storage/domain";
 import { getLocalRepository, LocalRepositoryPort } from "@/repositories";
 
 export const _getGameService = ({
@@ -6,6 +6,13 @@ export const _getGameService = ({
 }: {
   localRepository: LocalRepositoryPort;
 }) => {
+  const getStoryProgresses = async () => {
+    const user = await localRepository.getUser();
+    const progresses = await localRepository.getUserStoryProgresses(user?.key);
+
+    return progresses;
+  };
+
   return {
     saveProgress: async (
       progress: StoryProgress,
@@ -66,31 +73,7 @@ export const _getGameService = ({
       return await localRepository.getStoryProgress(storyKey);
     },
 
-    getStoryProgresses: async () => {
-      const user = await localRepository.getUser();
-      const progresses = await localRepository.getUserStoryProgresses(
-        user?.key,
-      );
-
-      return progresses;
-    },
-
-    loadGamesState: async ({
-      progresses,
-      libraryStories,
-    }: {
-      progresses: StoryProgress[];
-      libraryStories: { stories: Story[]; scenes: Scene[] };
-    }) => {
-      await localRepository.unitOfWork(
-        async () => {
-          await localRepository.updateOrCreateStoryProgresses(progresses);
-          await localRepository.updateOrCreateStories(libraryStories.stories);
-          await localRepository.updateOrCreateScenes(libraryStories.scenes);
-        },
-        { mode: "readwrite", entities: ["story", "scene", "story-progress"] },
-      );
-    },
+    getStoryProgresses,
   };
 };
 

--- a/client/src/domains/synchronization/sync-service.ts
+++ b/client/src/domains/synchronization/sync-service.ts
@@ -55,7 +55,7 @@ const _getSyncService = ({
           builderGames.stories,
           builderGames.scenes,
         ),
-        gameService.loadGamesState({
+        libraryService.loadLibraryState({
           progresses: storyProgresses,
           libraryStories: playerGames,
         }),

--- a/client/src/repositories/indexed-db-repository.ts
+++ b/client/src/repositories/indexed-db-repository.ts
@@ -91,6 +91,10 @@ const indexedDBRepository: LocalRepositoryPort = {
     await db.stories.delete(storyKey);
   },
 
+  deleteStories: async (storyKeys) => {
+    await db.stories.bulkDelete(storyKeys);
+  },
+
   // SCENES
 
   updateFirstScene: async (storyKey, sceneKey) => {
@@ -244,6 +248,10 @@ const indexedDBRepository: LocalRepositoryPort = {
   createStoryProgress: async (storyProgress) => {
     const key = await db.storyProgresses.add(storyProgress);
     return { ...storyProgress, key };
+  },
+
+  deleteStoryProgresses: async (keys) => {
+    await db.storyProgresses.bulkDelete(keys);
   },
 
   // OTHER

--- a/client/src/repositories/local-repository-port.ts
+++ b/client/src/repositories/local-repository-port.ts
@@ -26,6 +26,7 @@ export type LocalRepositoryPort = {
     username: string;
   }) => Promise<void>;
   deleteStory: (storyKey: string) => Promise<void>;
+  deleteStories: (storyKeys: string[]) => Promise<void>;
   getFinishedGameKeys: () => Promise<string[]>;
 
   createScene: (scene: WithoutKey<Scene>) => Promise<Scene>;
@@ -60,6 +61,7 @@ export type LocalRepositoryPort = {
   getMostRecentStoryProgress: (
     userKey: string | undefined,
   ) => Promise<StoryProgress | null>;
+  deleteStoryProgresses: (keys: string[]) => Promise<void>;
 
   getUser: () => Promise<User | null>;
   getUserCount: () => Promise<number>;

--- a/client/src/repositories/stubs/local-repository-stub.ts
+++ b/client/src/repositories/stubs/local-repository-stub.ts
@@ -59,6 +59,8 @@ export const getLocalRepositoryStub = (): MockLocalRepository => {
 
     deleteStory: mock(),
 
+    deleteStories: mock(),
+
     createStoryProgress: mock(BASIC_STORY_PROGRESS),
 
     updateOrCreateStoryProgresses: mock(["key"]),
@@ -72,6 +74,8 @@ export const getLocalRepositoryStub = (): MockLocalRepository => {
     getStoryProgressesOrderedByDate: mock([BASIC_STORY_PROGRESS]),
 
     getUserStoryProgresses: mock([BASIC_STORY_PROGRESS]),
+
+    deleteStoryProgresses: mock(),
 
     getUser: mock(BASIC_USER),
 


### PR DESCRIPTION
Au moment du load dans la synchro, il faut vider toute la DB (toutes les données relatives au user actuel) pour s'assurer que l'état de l'app est fidèle à l'état stocké côté cloud. 
Sans ça, les scènes supprimées sur un appareil A ne seraient pas supprimées au moment de load sur un appareil B. Et pareil pour les histoires et sauvegardes. 

Close #192 