### PR TITLE
Builder - Allow partial selection of nodes with shift key

### DIFF
--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -46,7 +46,7 @@ const BuilderFlow = () => {
       onNodesDelete={onNodesDelete}
       minZoom={0.1}
       defaultEdgeOptions={{ zIndex: 10000 }}
-      selectionMode={SelectionMode.Full}
+      selectionMode={SelectionMode.Partial}
       nodesFocusable
       selectionOnDrag
       selectNodesOnDrag


### PR DESCRIPTION
Close #157 

En fait ça marchait déjà, mais avec la touche shift, j'étais pas au courant mdr. J'ai juste permis de sélectionner les nodes même quand on les englobe pas entièrement.