### PR TITLE
 Builder - Update des valeurs du form ne s'affiche pas correctement dans le builder

### DIFF
--- a/client/src/builder/components/scene-editor/hooks/use-scene-editor-store.ts
+++ b/client/src/builder/components/scene-editor/hooks/use-scene-editor-store.ts
@@ -9,10 +9,16 @@ type SceneEditorStore = {
   close: () => void;
 };
 
+export const EMPTY_STATE: Omit<SceneEditorStore, "open" | "close"> = {
+  scene: null,
+  isFirstScene: null,
+  isOpen: false,
+};
+
 export const useSceneEditorStore = create<SceneEditorStore>((set) => ({
   scene: null,
   isFirstScene: null,
   isOpen: false,
   open: ({ scene, isFirstScene }) => set({ isOpen: true, scene, isFirstScene }),
-  close: () => set({ isOpen: false, isFirstScene: null, scene: null }),
+  close: () => set(EMPTY_STATE),
 }));

--- a/client/src/builder/hooks/use-builder-context.tsx
+++ b/client/src/builder/hooks/use-builder-context.tsx
@@ -5,14 +5,12 @@ import {
   PropsWithChildren,
   RefObject,
   useContext,
-  useEffect,
   useRef,
 } from "react";
 import { BuilderNode } from "../types";
 import { Edge } from "@xyflow/react";
 import { scenesToNodesAndEdgesAdapter } from "../adapters";
 import { RefreshFunction } from "../components/types";
-import { useSceneEditorStore } from "../components/scene-editor/hooks/use-scene-editor-store";
 
 type BuilderContext = {
   refresh: RefreshFunction;
@@ -24,6 +22,7 @@ type BuilderContext = {
 
 export const BuilderContext = createContext<BuilderContext | null>(null);
 
+// We have to be extra careful about the lifecycle of this component, as each re-render will trigger a rerender of the whole react flow interface
 export const BuilderContextProvider = ({
   children,
   scenes,
@@ -35,14 +34,8 @@ export const BuilderContextProvider = ({
   refresh: RefreshFunction;
 }>) => {
   const reactFlowRef = useRef<HTMLDivElement>(null);
-  const { close } = useSceneEditorStore();
 
   const [nodes, edges] = scenesToNodesAndEdgesAdapter({ scenes, story });
-
-  // Make sure that the scene editor is closed when another story is loaded in the builder
-  useEffect(() => {
-    close();
-  }, [close]);
 
   return (
     <BuilderContext.Provider

--- a/client/src/lib/storage/migrations/index.ts
+++ b/client/src/lib/storage/migrations/index.ts
@@ -12,14 +12,22 @@ export const executeMigrations = async () => {
     localStorage.getItem(LS_KEY) ?? "{}",
   );
 
+  let count = 0;
+  console.info("🎛️ Starting database migrations...");
+
   db.transaction("rw", TABLE_NAMES, async () => {
     for (let i = 0; i < MIGRATIONS.length; i++) {
       const migration = MIGRATIONS[i]!;
       if (migration.key in executedMigrations) continue;
 
+      console.info(`🔧 Performing migration [${migration.key}]`);
       await migration.migrate();
+      console.info(`🔧 Migration [${migration.key}] successfully executed`);
+      count++;
       executedMigrations[migration.key] = true;
       localStorage.setItem(LS_KEY, JSON.stringify(executedMigrations));
     }
   });
+
+  console.info(`✅ All ${count} migrations executed. Database is up-to-date.`);
 };

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -8,132 +8,56 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-// Import Routes
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as LibraryIndexRouteImport } from './routes/library/index'
+import { Route as LibraryStoryKeyRouteImport } from './routes/library/$storyKey'
+import { Route as BuilderStoriesRouteImport } from './routes/builder/stories'
+import { Route as BuilderStoryKeyRouteImport } from './routes/builder/$storyKey'
+import { Route as GameGameKeySceneKeyRouteImport } from './routes/game/$gameKey/$sceneKey'
+import { Route as GameTestGameKeySceneKeyRouteImport } from './routes/game/test/$gameKey/$sceneKey'
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as AboutImport } from './routes/about'
-import { Route as IndexImport } from './routes/index'
-import { Route as LibraryIndexImport } from './routes/library/index'
-import { Route as LibraryStoryKeyImport } from './routes/library/$storyKey'
-import { Route as BuilderStoriesImport } from './routes/builder/stories'
-import { Route as BuilderStoryKeyImport } from './routes/builder/$storyKey'
-import { Route as GameGameKeySceneKeyImport } from './routes/game/$gameKey/$sceneKey'
-import { Route as GameTestGameKeySceneKeyImport } from './routes/game/test/$gameKey/$sceneKey'
-
-// Create/Update Routes
-
-const AboutRoute = AboutImport.update({
+const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const IndexRoute = IndexImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const LibraryIndexRoute = LibraryIndexImport.update({
+const LibraryIndexRoute = LibraryIndexRouteImport.update({
   id: '/library/',
   path: '/library/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const LibraryStoryKeyRoute = LibraryStoryKeyImport.update({
+const LibraryStoryKeyRoute = LibraryStoryKeyRouteImport.update({
   id: '/library/$storyKey',
   path: '/library/$storyKey',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const BuilderStoriesRoute = BuilderStoriesImport.update({
+const BuilderStoriesRoute = BuilderStoriesRouteImport.update({
   id: '/builder/stories',
   path: '/builder/stories',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const BuilderStoryKeyRoute = BuilderStoryKeyImport.update({
+const BuilderStoryKeyRoute = BuilderStoryKeyRouteImport.update({
   id: '/builder/$storyKey',
   path: '/builder/$storyKey',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const GameGameKeySceneKeyRoute = GameGameKeySceneKeyImport.update({
+const GameGameKeySceneKeyRoute = GameGameKeySceneKeyRouteImport.update({
   id: '/game/$gameKey/$sceneKey',
   path: '/game/$gameKey/$sceneKey',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const GameTestGameKeySceneKeyRoute = GameTestGameKeySceneKeyImport.update({
+const GameTestGameKeySceneKeyRoute = GameTestGameKeySceneKeyRouteImport.update({
   id: '/game/test/$gameKey/$sceneKey',
   path: '/game/test/$gameKey/$sceneKey',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-// Populate the FileRoutesByPath interface
-
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutImport
-      parentRoute: typeof rootRoute
-    }
-    '/builder/$storyKey': {
-      id: '/builder/$storyKey'
-      path: '/builder/$storyKey'
-      fullPath: '/builder/$storyKey'
-      preLoaderRoute: typeof BuilderStoryKeyImport
-      parentRoute: typeof rootRoute
-    }
-    '/builder/stories': {
-      id: '/builder/stories'
-      path: '/builder/stories'
-      fullPath: '/builder/stories'
-      preLoaderRoute: typeof BuilderStoriesImport
-      parentRoute: typeof rootRoute
-    }
-    '/library/$storyKey': {
-      id: '/library/$storyKey'
-      path: '/library/$storyKey'
-      fullPath: '/library/$storyKey'
-      preLoaderRoute: typeof LibraryStoryKeyImport
-      parentRoute: typeof rootRoute
-    }
-    '/library/': {
-      id: '/library/'
-      path: '/library'
-      fullPath: '/library'
-      preLoaderRoute: typeof LibraryIndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/game/$gameKey/$sceneKey': {
-      id: '/game/$gameKey/$sceneKey'
-      path: '/game/$gameKey/$sceneKey'
-      fullPath: '/game/$gameKey/$sceneKey'
-      preLoaderRoute: typeof GameGameKeySceneKeyImport
-      parentRoute: typeof rootRoute
-    }
-    '/game/test/$gameKey/$sceneKey': {
-      id: '/game/test/$gameKey/$sceneKey'
-      path: '/game/test/$gameKey/$sceneKey'
-      fullPath: '/game/test/$gameKey/$sceneKey'
-      preLoaderRoute: typeof GameTestGameKeySceneKeyImport
-      parentRoute: typeof rootRoute
-    }
-  }
-}
-
-// Create and export the route tree
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -145,7 +69,6 @@ export interface FileRoutesByFullPath {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
-
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
@@ -156,9 +79,8 @@ export interface FileRoutesByTo {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
-
 export interface FileRoutesById {
-  __root__: typeof rootRoute
+  __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/builder/$storyKey': typeof BuilderStoryKeyRoute
@@ -168,7 +90,6 @@ export interface FileRoutesById {
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
-
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
@@ -202,7 +123,6 @@ export interface FileRouteTypes {
     | '/game/test/$gameKey/$sceneKey'
   fileRoutesById: FileRoutesById
 }
-
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
@@ -212,6 +132,67 @@ export interface RootRouteChildren {
   LibraryIndexRoute: typeof LibraryIndexRoute
   GameGameKeySceneKeyRoute: typeof GameGameKeySceneKeyRoute
   GameTestGameKeySceneKeyRoute: typeof GameTestGameKeySceneKeyRoute
+}
+
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/library/': {
+      id: '/library/'
+      path: '/library'
+      fullPath: '/library'
+      preLoaderRoute: typeof LibraryIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/library/$storyKey': {
+      id: '/library/$storyKey'
+      path: '/library/$storyKey'
+      fullPath: '/library/$storyKey'
+      preLoaderRoute: typeof LibraryStoryKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/builder/stories': {
+      id: '/builder/stories'
+      path: '/builder/stories'
+      fullPath: '/builder/stories'
+      preLoaderRoute: typeof BuilderStoriesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/builder/$storyKey': {
+      id: '/builder/$storyKey'
+      path: '/builder/$storyKey'
+      fullPath: '/builder/$storyKey'
+      preLoaderRoute: typeof BuilderStoryKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/game/$gameKey/$sceneKey': {
+      id: '/game/$gameKey/$sceneKey'
+      path: '/game/$gameKey/$sceneKey'
+      fullPath: '/game/$gameKey/$sceneKey'
+      preLoaderRoute: typeof GameGameKeySceneKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/game/test/$gameKey/$sceneKey': {
+      id: '/game/test/$gameKey/$sceneKey'
+      path: '/game/test/$gameKey/$sceneKey'
+      fullPath: '/game/test/$gameKey/$sceneKey'
+      preLoaderRoute: typeof GameTestGameKeySceneKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -224,51 +205,6 @@ const rootRouteChildren: RootRouteChildren = {
   GameGameKeySceneKeyRoute: GameGameKeySceneKeyRoute,
   GameTestGameKeySceneKeyRoute: GameTestGameKeySceneKeyRoute,
 }
-
-export const routeTree = rootRoute
+export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-/* ROUTE_MANIFEST_START
-{
-  "routes": {
-    "__root__": {
-      "filePath": "__root.tsx",
-      "children": [
-        "/",
-        "/about",
-        "/builder/$storyKey",
-        "/builder/stories",
-        "/library/$storyKey",
-        "/library/",
-        "/game/$gameKey/$sceneKey",
-        "/game/test/$gameKey/$sceneKey"
-      ]
-    },
-    "/": {
-      "filePath": "index.tsx"
-    },
-    "/about": {
-      "filePath": "about.tsx"
-    },
-    "/builder/$storyKey": {
-      "filePath": "builder/$storyKey.tsx"
-    },
-    "/builder/stories": {
-      "filePath": "builder/stories.tsx"
-    },
-    "/library/$storyKey": {
-      "filePath": "library/$storyKey.tsx"
-    },
-    "/library/": {
-      "filePath": "library/index.tsx"
-    },
-    "/game/$gameKey/$sceneKey": {
-      "filePath": "game/$gameKey/$sceneKey.tsx"
-    },
-    "/game/test/$gameKey/$sceneKey": {
-      "filePath": "game/test/$gameKey/$sceneKey.tsx"
-    }
-  }
-}
-ROUTE_MANIFEST_END */

--- a/client/src/routes/builder/$storyKey.tsx
+++ b/client/src/routes/builder/$storyKey.tsx
@@ -1,4 +1,8 @@
 import { BuilderContainer } from "@/builder/components/builder-container";
+import {
+  EMPTY_STATE,
+  useSceneEditorStore,
+} from "@/builder/components/scene-editor/hooks/use-scene-editor-store";
 import { BackdropLoader, ErrorMessage } from "@/design-system/components";
 import { getBuilderService } from "@/get-builder-service";
 import { useQuery } from "@tanstack/react-query";
@@ -38,4 +42,7 @@ const Page = () => {
 
 export const Route = createFileRoute("/builder/$storyKey")({
   component: Page,
+  onLeave: () => {
+    useSceneEditorStore.setState(EMPTY_STATE);
+  },
 });


### PR DESCRIPTION
En gros c'était un problème de lifecycle qui dans le provider du builder, où on avait un rerender dès que le store qui gère l'état du formulaire de création de scène changeait.
Ce qui se passait : 
1. Update des valeurs de la scène lors de l'édition 
2. Fermeture du formulaire - déclenche une modification du store, donc =>
3. Rerender dans le provider du builder 
4. Le provider du builder actualise la donnée du builder à partir des dernières infos récoltées, c'est-à-dire avant l'update (infos stale) 

Donc à la place on vient fermer le formulaire quand on quitte le builder, ce qui fix le pb mais c'est vrai que le bug soulève des questions plus générales sur le lifecycle du builder. Notamment il faudrait peut-être pas que le provider fasse autant de trucs, et peut-être qu'on devrait invalider les queries quand on update des trucs dans le builder (potentiellement à gérer dans https://github.com/JeremieLeymarie/story-builder/issues/215)

Close #243 