### PR TITLE
Streamline le workflow du builder (partie 1)

### DIFF
--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -21,12 +21,30 @@ const nodeTypes = { scene: SceneNode };
 const BuilderFlow = () => {
   const { reactFlowRef } = useBuilderContext();
   const { close: closeNewEditor } = useSceneEditorStore();
-  const { props } = useBuilder();
+  const {
+    nodes,
+    edges,
+    onConnect,
+    onConnectEnd,
+    onEdgesChange,
+    onEdgesDelete,
+    onNodeDragStop,
+    onNodesChange,
+    onNodesDelete,
+  } = useBuilder();
 
   return (
     <ReactFlow
       nodeTypes={nodeTypes}
-      {...props}
+      nodes={nodes}
+      edges={edges}
+      onConnect={onConnect}
+      onConnectEnd={onConnectEnd}
+      onEdgesChange={onEdgesChange}
+      onEdgesDelete={onEdgesDelete}
+      onNodeDragStop={onNodeDragStop}
+      onNodesChange={onNodesChange}
+      onNodesDelete={onNodesDelete}
       nodeOrigin={[0, 0.5]}
       minZoom={0.1}
       defaultEdgeOptions={{ zIndex: 10000 }}

--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -4,6 +4,8 @@ import {
   BackgroundVariant,
   MiniMap,
   SelectionMode,
+  ReactFlowProps,
+  Edge,
 } from "@xyflow/react";
 import { SceneNode } from "./nodes/scene/scene";
 import { Toolbar } from "./toolbar";
@@ -15,10 +17,17 @@ import { FIT_VIEW_DURATION } from "../constants";
 import { SceneEditor } from "./scene-editor/scene-editor-drawer";
 import { useSceneEditorStore } from "./scene-editor/hooks/use-scene-editor-store";
 import { useBuilderActions } from "../hooks/use-builder-actions";
+import { SceneNodeType } from "../types";
 
 const nodeTypes = { scene: SceneNode };
 
-const BuilderFlow = () => {
+export const BuilderFlow = ({
+  propsOverride,
+  showcaseMode,
+}: {
+  propsOverride?: ReactFlowProps<SceneNodeType, Edge>;
+  showcaseMode?: boolean;
+}) => {
   const { reactFlowRef } = useBuilderContext();
   const { close: closeNewEditor } = useSceneEditorStore();
   const {
@@ -50,15 +59,15 @@ const BuilderFlow = () => {
       defaultEdgeOptions={{ zIndex: 10000 }}
       selectionMode={SelectionMode.Partial}
       nodesFocusable
-      selectionOnDrag
       selectNodesOnDrag
       ref={reactFlowRef}
       fitView
       multiSelectionKeyCode={getUserOS() === "Mac" ? "Meta" : "ControlLeft"}
       fitViewOptions={{ duration: FIT_VIEW_DURATION }}
       onPaneClick={closeNewEditor}
+      {...propsOverride}
     >
-      <MiniMap position="bottom-left" />
+      {!showcaseMode && <MiniMap position="bottom-left" />}
       <Background variant={BackgroundVariant.Dots} gap={25} size={1.5} />
     </ReactFlow>
   );

--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -7,7 +7,7 @@ import {
 } from "@xyflow/react";
 import { SceneNode } from "./nodes/scene/scene";
 import { Toolbar } from "./toolbar";
-import { BuilderMeta, useBuilder } from "../hooks/use-builder";
+import { useBuilder } from "../hooks/use-builder";
 import { useBuilderContext } from "../hooks/use-builder-context";
 import { getUserOS } from "@/lib/get-os";
 import { ActionsBar } from "./actions-bar";
@@ -18,14 +18,16 @@ import { useBuilderActions } from "../hooks/use-builder-actions";
 
 const nodeTypes = { scene: SceneNode };
 
-const BuilderFlow = ({ attributes }: BuilderMeta) => {
+const BuilderFlow = () => {
   const { reactFlowRef } = useBuilderContext();
   const { close: closeNewEditor } = useSceneEditorStore();
+  const { props } = useBuilder();
 
   return (
     <ReactFlow
       nodeTypes={nodeTypes}
-      {...attributes}
+      {...props}
+      nodeOrigin={[0, 0.5]}
       minZoom={0.1}
       defaultEdgeOptions={{ zIndex: 10000 }}
       selectionMode={SelectionMode.Partial}
@@ -46,18 +48,17 @@ const BuilderFlow = ({ attributes }: BuilderMeta) => {
 
 export const Builder = () => {
   const { updateScene } = useBuilderActions();
-  const builder = useBuilder();
 
   return (
     <div className="relative flex h-full w-full border">
       <div className="absolute top-5 left-5 flex flex-col gap-4">
-        <Toolbar setNodes={builder.setNodes} />
+        <Toolbar />
         <ActionsBar />
       </div>
       <div className="absolute top-5 right-5 flex flex-col gap-4">
         <SceneEditor onSave={updateScene} />
       </div>
-      <BuilderFlow {...builder} />
+      <BuilderFlow />
     </div>
   );
 };

--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -7,7 +7,7 @@ import {
 } from "@xyflow/react";
 import { SceneNode } from "./nodes/scene/scene";
 import { Toolbar } from "./toolbar";
-import { useBuilder } from "../hooks/use-builder";
+import { BuilderMeta, useBuilder } from "../hooks/use-builder";
 import { useBuilderContext } from "../hooks/use-builder-context";
 import { getUserOS } from "@/lib/get-os";
 import { ActionsBar } from "./actions-bar";
@@ -18,32 +18,14 @@ import { useBuilderActions } from "../hooks/use-builder-actions";
 
 const nodeTypes = { scene: SceneNode };
 
-const BuilderFlow = () => {
-  const {
-    edges,
-    nodes,
-    onConnect,
-    onEdgesChange,
-    onNodeMove,
-    onNodesChange,
-    onNodesDelete,
-    onEdgesDelete,
-  } = useBuilder();
-
+const BuilderFlow = ({ attributes }: BuilderMeta) => {
   const { reactFlowRef } = useBuilderContext();
   const { close: closeNewEditor } = useSceneEditorStore();
 
   return (
     <ReactFlow
       nodeTypes={nodeTypes}
-      nodes={nodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect}
-      onNodeDragStop={onNodeMove}
-      onEdgesDelete={onEdgesDelete}
-      onNodesDelete={onNodesDelete}
+      {...attributes}
       minZoom={0.1}
       defaultEdgeOptions={{ zIndex: 10000 }}
       selectionMode={SelectionMode.Partial}
@@ -64,17 +46,18 @@ const BuilderFlow = () => {
 
 export const Builder = () => {
   const { updateScene } = useBuilderActions();
+  const builder = useBuilder();
 
   return (
     <div className="relative flex h-full w-full border">
       <div className="absolute top-5 left-5 flex flex-col gap-4">
-        <Toolbar />
+        <Toolbar setNodes={builder.setNodes} />
         <ActionsBar />
       </div>
       <div className="absolute top-5 right-5 flex flex-col gap-4">
         <SceneEditor onSave={updateScene} />
       </div>
-      <BuilderFlow />
+      <BuilderFlow {...builder} />
     </div>
   );
 };

--- a/client/src/builder/components/builder.tsx
+++ b/client/src/builder/components/builder.tsx
@@ -4,8 +4,6 @@ import {
   BackgroundVariant,
   MiniMap,
   SelectionMode,
-  ReactFlowProps,
-  Edge,
 } from "@xyflow/react";
 import { SceneNode } from "./nodes/scene/scene";
 import { Toolbar } from "./toolbar";
@@ -17,17 +15,10 @@ import { FIT_VIEW_DURATION } from "../constants";
 import { SceneEditor } from "./scene-editor/scene-editor-drawer";
 import { useSceneEditorStore } from "./scene-editor/hooks/use-scene-editor-store";
 import { useBuilderActions } from "../hooks/use-builder-actions";
-import { SceneNodeType } from "../types";
 
 const nodeTypes = { scene: SceneNode };
 
-export const BuilderFlow = ({
-  propsOverride,
-  showcaseMode,
-}: {
-  propsOverride?: ReactFlowProps<SceneNodeType, Edge>;
-  showcaseMode?: boolean;
-}) => {
+const BuilderFlow = () => {
   const { reactFlowRef } = useBuilderContext();
   const { close: closeNewEditor } = useSceneEditorStore();
   const {
@@ -59,15 +50,15 @@ export const BuilderFlow = ({
       defaultEdgeOptions={{ zIndex: 10000 }}
       selectionMode={SelectionMode.Partial}
       nodesFocusable
+      selectionOnDrag
       selectNodesOnDrag
       ref={reactFlowRef}
       fitView
       multiSelectionKeyCode={getUserOS() === "Mac" ? "Meta" : "ControlLeft"}
       fitViewOptions={{ duration: FIT_VIEW_DURATION }}
       onPaneClick={closeNewEditor}
-      {...propsOverride}
     >
-      {!showcaseMode && <MiniMap position="bottom-left" />}
+      <MiniMap position="bottom-left" />
       <Background variant={BackgroundVariant.Dots} gap={25} size={1.5} />
     </ReactFlow>
   );

--- a/client/src/builder/components/toolbar.tsx
+++ b/client/src/builder/components/toolbar.tsx
@@ -6,17 +6,11 @@ import { DeleteModal } from "./delete-modal";
 import { ButtonShortCutDoc } from "@/design-system/components/shortcut-doc";
 import { useBuilderContext } from "../hooks/use-builder-context";
 import { useAddScene } from "../hooks/use-add-scene";
-import { Dispatch, SetStateAction } from "react";
-import { SceneNodeType } from "../types";
 
-export const Toolbar = ({
-  setNodes,
-}: {
-  setNodes: Dispatch<SetStateAction<SceneNodeType[]>>;
-}) => {
+export const Toolbar = () => {
   const { story } = useBuilderContext();
   const { testStory, deleteStory } = useToolbar({ storyKey: story.key });
-  const { addScene } = useAddScene(setNodes);
+  const { addScene } = useAddScene();
 
   return (
     <div className="z-50 w-[250px] rounded border bg-white/80 p-4 shadow-sm">

--- a/client/src/builder/components/toolbar.tsx
+++ b/client/src/builder/components/toolbar.tsx
@@ -6,12 +6,17 @@ import { DeleteModal } from "./delete-modal";
 import { ButtonShortCutDoc } from "@/design-system/components/shortcut-doc";
 import { useBuilderContext } from "../hooks/use-builder-context";
 import { useAddScene } from "../hooks/use-add-scene";
-import { makeSimpleSceneContent } from "@/lib/scene-content";
+import { Dispatch, SetStateAction } from "react";
+import { SceneNodeType } from "../types";
 
-export const Toolbar = () => {
+export const Toolbar = ({
+  setNodes,
+}: {
+  setNodes: Dispatch<SetStateAction<SceneNodeType[]>>;
+}) => {
   const { story } = useBuilderContext();
   const { testStory, deleteStory } = useToolbar({ storyKey: story.key });
-  const { addScene } = useAddScene();
+  const { addScene } = useAddScene(setNodes);
 
   return (
     <div className="z-50 w-[250px] rounded border bg-white/80 p-4 shadow-sm">
@@ -21,11 +26,7 @@ export const Toolbar = () => {
           size="sm"
           className="flex w-full justify-start"
           onClick={() => {
-            addScene({
-              title: "",
-              content: makeSimpleSceneContent(""),
-              actions: [],
-            });
+            addScene();
           }}
         >
           <BookOpenTextIcon size="16px" />

--- a/client/src/builder/hooks/use-add-scene.ts
+++ b/client/src/builder/hooks/use-add-scene.ts
@@ -27,17 +27,17 @@ export const useAddScene = () => {
       x: rect.x + rect.width / 2,
       y: rect.y + rect.height / 2,
     };
-    return position;
+    return screenToFlowPosition(position);
   };
 
   const addScene = async (
     position: XYPosition = getCenterPosition(),
-    keyless_scene: SceneSchema = DEFAULT_SCENE,
+    keylessScene: SceneSchema = DEFAULT_SCENE,
   ): Promise<Scene> => {
     const scene = await builderService.addScene({
-      ...keyless_scene,
+      ...keylessScene,
       storyKey: story.key,
-      builderParams: { position: screenToFlowPosition(position) },
+      builderParams: { position },
     });
     setNodes((nds) => [...nds, sceneToNodeAdapter({ scene, story })]);
     return scene;

--- a/client/src/builder/hooks/use-builder-edges.tsx
+++ b/client/src/builder/hooks/use-builder-edges.tsx
@@ -28,6 +28,7 @@ export const useBuilderEdges = () => {
       }
 
       const sceneToUpdate = nodeToSceneAdapter(sourceScene);
+
       return { sceneToUpdate, actionIndex };
     },
     [getNodes],

--- a/client/src/builder/hooks/use-builder-edges.tsx
+++ b/client/src/builder/hooks/use-builder-edges.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback } from "react";
+import { useCallback } from "react";
 import {
   Connection,
   Edge,
@@ -10,36 +10,24 @@ import {
 import { nodeToSceneAdapter } from "../adapters";
 import { getBuilderService } from "@/get-builder-service";
 import { DEFAULT_SCENE, useAddScene } from "./use-add-scene";
-import { Story } from "@/lib/storage/domain";
 import { BuilderNode } from "../types";
 
-export const useBuilderEdges = ({
-  setEdges,
-}: {
-  story: Story;
-  setEdges: Dispatch<SetStateAction<Edge[]>>;
-}) => {
-  const { getNodes } = useReactFlow<BuilderNode>();
+export const useBuilderEdges = () => {
+  const { getNodes, setEdges } = useReactFlow<BuilderNode>();
 
   const getSceneToUpdate = useCallback(
     (edge: Edge | Connection) => {
       const sourceScene = getNodes().find((scene) => scene.id === edge.source);
 
       const actionIndex = parseInt(
-        edge.sourceHandle?.split("-").at(-1) ?? "-1",
+        edge.sourceHandle?.split("-").at(-1) ?? "NaN",
       );
 
-      if (
-        !sourceScene ||
-        edge.target === null ||
-        actionIndex === -1 ||
-        Number.isNaN(actionIndex)
-      ) {
+      if (!sourceScene || Number.isNaN(actionIndex)) {
         return null;
       }
 
       const sceneToUpdate = nodeToSceneAdapter(sourceScene);
-
       return { sceneToUpdate, actionIndex };
     },
     [getNodes],
@@ -55,7 +43,7 @@ export const useBuilderEdges = ({
 
       getBuilderService().addSceneConnection({
         sourceScene: sceneData.sceneToUpdate,
-        destinationSceneKey: connection.target!,
+        destinationSceneKey: connection.target,
         actionIndex: sceneData.actionIndex,
       });
 

--- a/client/src/builder/hooks/use-builder-edges.tsx
+++ b/client/src/builder/hooks/use-builder-edges.tsx
@@ -3,28 +3,28 @@ import {
   Connection,
   Edge,
   FinalConnectionState,
-  Node,
   addEdge,
   reconnectEdge,
+  useReactFlow,
 } from "@xyflow/react";
-import { SceneProps } from "../types";
 import { nodeToSceneAdapter, sceneToNodeAdapter } from "../adapters";
 import { getBuilderService } from "@/get-builder-service";
 import { useAddScene } from "./use-add-scene";
 import { Story } from "@/lib/storage/domain";
+import { BuilderNode } from "../types";
 
 export const useBuilderEdges = ({
-  sceneNodes,
   story,
   setEdges,
 }: {
-  sceneNodes: Node<SceneProps, "scene">[];
   story: Story;
   setEdges: Dispatch<SetStateAction<Edge[]>>;
 }) => {
+  const { getNodes } = useReactFlow<BuilderNode>();
+
   const getSceneToUpdate = useCallback(
     (edge: Edge | Connection) => {
-      const sourceScene = sceneNodes.find((scene) => scene.id === edge.source);
+      const sourceScene = getNodes().find((scene) => scene.id === edge.source);
 
       const actionIndex = parseInt(
         edge.sourceHandle?.split("-").at(-1) ?? "-1",
@@ -43,14 +43,14 @@ export const useBuilderEdges = ({
 
       return { sceneToUpdate, actionIndex };
     },
-    [sceneNodes],
+    [getNodes],
   );
 
   const onConnect = useCallback(
     (connection: Connection) => {
       const sceneData = getSceneToUpdate(connection);
       if (!sceneData) {
-        // TODO: Add toast
+        console.error("Connection error: scene data is null");
         return;
       }
 

--- a/client/src/builder/hooks/use-builder-shortcuts.ts
+++ b/client/src/builder/hooks/use-builder-shortcuts.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect } from "react";
+import { Dispatch, SetStateAction, useCallback, useEffect } from "react";
 import { useTestStory } from "./use-test-story";
 import { useExportModalStore } from "./use-export-modal-store";
 import { useAddScene } from "./use-add-scene";
-import { makeSimpleSceneContent } from "@/lib/scene-content";
+import { SceneNodeType } from "../types";
 
 const isAnyInputFocused = () => {
   const isInputFocused = document.activeElement?.tagName === "INPUT";
@@ -18,10 +18,12 @@ const isAnyModalOpen = () => document.body.style.pointerEvents === "none";
 
 export const useBuilderShortCuts = ({
   firstSceneKey,
+  setNodes,
 }: {
   firstSceneKey: string;
+  setNodes: Dispatch<SetStateAction<SceneNodeType[]>>;
 }) => {
-  const { addScene } = useAddScene();
+  const { addScene } = useAddScene(setNodes);
   const { setOpen: openExportModal } = useExportModalStore();
   const { testStory } = useTestStory();
 
@@ -34,11 +36,7 @@ export const useBuilderShortCuts = ({
       switch (key) {
         case "n":
           if (isAnyModalOpen()) return;
-          addScene({
-            actions: [],
-            content: makeSimpleSceneContent(""),
-            title: "",
-          });
+          addScene();
           e.preventDefault();
           break;
         case "t":

--- a/client/src/builder/hooks/use-builder-shortcuts.ts
+++ b/client/src/builder/hooks/use-builder-shortcuts.ts
@@ -1,8 +1,7 @@
-import { Dispatch, SetStateAction, useCallback, useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { useTestStory } from "./use-test-story";
 import { useExportModalStore } from "./use-export-modal-store";
 import { useAddScene } from "./use-add-scene";
-import { SceneNodeType } from "../types";
 
 const isAnyInputFocused = () => {
   const isInputFocused = document.activeElement?.tagName === "INPUT";
@@ -18,12 +17,10 @@ const isAnyModalOpen = () => document.body.style.pointerEvents === "none";
 
 export const useBuilderShortCuts = ({
   firstSceneKey,
-  setNodes,
 }: {
   firstSceneKey: string;
-  setNodes: Dispatch<SetStateAction<SceneNodeType[]>>;
 }) => {
-  const { addScene } = useAddScene(setNodes);
+  const { addScene } = useAddScene();
   const { setOpen: openExportModal } = useExportModalStore();
   const { testStory } = useTestStory();
 

--- a/client/src/builder/hooks/use-builder.tsx
+++ b/client/src/builder/hooks/use-builder.tsx
@@ -41,16 +41,14 @@ export const useBuilder = () => {
   };
 
   return {
-    props: {
-      nodes: nodes.map((node) => ({ ...node, selectable: true })),
-      edges,
-      onNodeDragStop,
-      onNodesChange,
-      onEdgesChange,
-      onNodesDelete,
-      onConnect,
-      onConnectEnd,
-      onEdgesDelete,
-    },
+    nodes: nodes.map((node) => ({ ...node, selectable: true })),
+    edges,
+    onNodeDragStop,
+    onNodesChange,
+    onEdgesChange,
+    onNodesDelete,
+    onConnect,
+    onConnectEnd,
+    onEdgesDelete,
   };
 };

--- a/client/src/builder/hooks/use-builder.tsx
+++ b/client/src/builder/hooks/use-builder.tsx
@@ -1,18 +1,7 @@
-import { Dispatch, MouseEvent, SetStateAction, useEffect } from "react";
-import {
-  useNodesState,
-  useEdgesState,
-  OnNodeDrag,
-  Edge,
-  OnNodesChange,
-  OnEdgesChange,
-  OnNodesDelete,
-  OnConnect,
-  OnConnectEnd,
-  OnEdgesDelete,
-} from "@xyflow/react";
+import { MouseEvent, useEffect } from "react";
+import { useNodesState, useEdgesState } from "@xyflow/react";
 import { useBuilderEdges } from "./use-builder-edges";
-import { BuilderNode, SceneNodeType } from "../types";
+import { BuilderNode } from "../types";
 import { useBuilderShortCuts } from "./use-builder-shortcuts";
 import { useBuilderContext } from "./use-builder-context";
 import { getBuilderService } from "@/get-builder-service";
@@ -20,7 +9,7 @@ import { getBuilderService } from "@/get-builder-service";
 // For now state is entirely dictated by the local dexie-db, but this could be a performance
 // issue in very large stories
 
-export function useBuilder(): BuilderMeta {
+export const useBuilder = () => {
   const {
     edges: edgesFromContext,
     nodes: nodesFromContext,
@@ -34,10 +23,9 @@ export function useBuilder(): BuilderMeta {
     sceneNodes: nodesFromContext,
     story,
     setEdges,
-    setNodes,
   });
 
-  useBuilderShortCuts({ firstSceneKey: story.firstSceneKey, setNodes });
+  useBuilderShortCuts({ firstSceneKey: story.firstSceneKey });
 
   useEffect(() => {
     setNodes(nodesFromContext);
@@ -54,8 +42,7 @@ export function useBuilder(): BuilderMeta {
   };
 
   return {
-    setNodes,
-    attributes: {
+    props: {
       nodes: nodes.map((node) => ({ ...node, selectable: true })),
       edges,
       onNodeDragStop,
@@ -66,20 +53,5 @@ export function useBuilder(): BuilderMeta {
       onConnectEnd,
       onEdgesDelete,
     },
-  };
-}
-
-export type BuilderMeta = {
-  setNodes: Dispatch<SetStateAction<SceneNodeType[]>>;
-  attributes: {
-    nodes: SceneNodeType[];
-    edges: Edge[];
-    onNodeDragStop: OnNodeDrag<BuilderNode>;
-    onNodesChange: OnNodesChange<BuilderNode>;
-    onEdgesChange: OnEdgesChange<Edge>;
-    onNodesDelete: OnNodesDelete<BuilderNode>;
-    onConnect: OnConnect;
-    onConnectEnd: OnConnectEnd;
-    onEdgesDelete: OnEdgesDelete<Edge>;
   };
 };

--- a/client/src/builder/hooks/use-builder.tsx
+++ b/client/src/builder/hooks/use-builder.tsx
@@ -19,10 +19,7 @@ export const useBuilder = () => {
   const [edges, setEdges, onEdgesChange] = useEdgesState(edgesFromContext);
 
   const builderService = getBuilderService();
-  const { onConnect, onConnectEnd, onEdgesDelete } = useBuilderEdges({
-    story,
-    setEdges,
-  });
+  const { onConnect, onConnectEnd, onEdgesDelete } = useBuilderEdges();
 
   useBuilderShortCuts({ firstSceneKey: story.firstSceneKey });
 

--- a/client/src/builder/hooks/use-builder.tsx
+++ b/client/src/builder/hooks/use-builder.tsx
@@ -20,7 +20,6 @@ export const useBuilder = () => {
 
   const builderService = getBuilderService();
   const { onConnect, onConnectEnd, onEdgesDelete } = useBuilderEdges({
-    sceneNodes: nodesFromContext,
     story,
     setEdges,
   });

--- a/client/src/home/builder-showcase.tsx
+++ b/client/src/home/builder-showcase.tsx
@@ -1,18 +1,22 @@
+import { SceneNode } from "@/builder/components/nodes/scene/scene";
 import { SceneNodeType } from "@/builder/types";
 import { Title } from "@/design-system/components";
 import { Button } from "@/design-system/primitives";
 import { Link } from "@tanstack/react-router";
 import { MoveRightIcon } from "lucide-react";
 import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
   Edge,
   useEdgesState,
   useNodesState,
-  ReactFlowProvider,
 } from "@xyflow/react";
 import { BuilderContextProvider } from "@/builder/hooks/use-builder-context";
 import { Story } from "@/lib/storage/domain";
 import { makeSimpleSceneContent } from "@/lib/scene-content";
-import { BuilderFlow } from "@/builder/components/builder";
+
+const nodeTypes = { scene: SceneNode };
 
 const NODES: SceneNodeType[] = [
   {
@@ -126,31 +130,21 @@ export const BuilderShowcase = () => {
           story={MOCK_STORY}
           scenes={[]}
         >
-          <ReactFlowProvider>
-            <BuilderFlow
-              propsOverride={{
-                nodes,
-                edges,
-                onNodesChange: (changes) =>
-                  onNodesChange(
-                    changes.filter((change) => change.type !== "add"),
-                  ),
-                onConnectEnd: undefined,
-                onEdgesChange,
-                panOnScroll: false,
-                preventScrolling: false,
-                panOnDrag: false,
-                panActivationKeyCode: null,
-                autoPanOnNodeDrag: false,
-                autoPanOnConnect: false,
-                zoomOnScroll: false,
-                zoomOnDoubleClick: false,
-                zoomOnPinch: false,
-                zoomActivationKeyCode: null,
-              }}
-              showcaseMode={true}
-            />
-          </ReactFlowProvider>
+          <ReactFlow
+            nodeTypes={nodeTypes}
+            nodes={nodes}
+            onNodesChange={onNodesChange}
+            edges={edges}
+            onEdgesChange={onEdgesChange}
+            minZoom={0.05}
+            zoomOnScroll={false}
+            panOnScroll={false}
+            defaultEdgeOptions={{ zIndex: 10000 }}
+            preventScrolling={false}
+            fitView
+          >
+            <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+          </ReactFlow>
         </BuilderContextProvider>
       </div>
     </div>

--- a/client/src/home/builder-showcase.tsx
+++ b/client/src/home/builder-showcase.tsx
@@ -1,22 +1,18 @@
-import { SceneNode } from "@/builder/components/nodes/scene/scene";
 import { SceneNodeType } from "@/builder/types";
 import { Title } from "@/design-system/components";
 import { Button } from "@/design-system/primitives";
 import { Link } from "@tanstack/react-router";
 import { MoveRightIcon } from "lucide-react";
 import {
-  ReactFlow,
-  Background,
-  BackgroundVariant,
   Edge,
   useEdgesState,
   useNodesState,
+  ReactFlowProvider,
 } from "@xyflow/react";
 import { BuilderContextProvider } from "@/builder/hooks/use-builder-context";
 import { Story } from "@/lib/storage/domain";
 import { makeSimpleSceneContent } from "@/lib/scene-content";
-
-const nodeTypes = { scene: SceneNode };
+import { BuilderFlow } from "@/builder/components/builder";
 
 const NODES: SceneNodeType[] = [
   {
@@ -130,21 +126,31 @@ export const BuilderShowcase = () => {
           story={MOCK_STORY}
           scenes={[]}
         >
-          <ReactFlow
-            nodeTypes={nodeTypes}
-            nodes={nodes}
-            onNodesChange={onNodesChange}
-            edges={edges}
-            onEdgesChange={onEdgesChange}
-            minZoom={0.05}
-            zoomOnScroll={false}
-            panOnScroll={false}
-            defaultEdgeOptions={{ zIndex: 10000 }}
-            preventScrolling={false}
-            fitView
-          >
-            <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
-          </ReactFlow>
+          <ReactFlowProvider>
+            <BuilderFlow
+              propsOverride={{
+                nodes,
+                edges,
+                onNodesChange: (changes) =>
+                  onNodesChange(
+                    changes.filter((change) => change.type !== "add"),
+                  ),
+                onConnectEnd: undefined,
+                onEdgesChange,
+                panOnScroll: false,
+                preventScrolling: false,
+                panOnDrag: false,
+                panActivationKeyCode: null,
+                autoPanOnNodeDrag: false,
+                autoPanOnConnect: false,
+                zoomOnScroll: false,
+                zoomOnDoubleClick: false,
+                zoomOnPinch: false,
+                zoomActivationKeyCode: null,
+              }}
+              showcaseMode={true}
+            />
+          </ReactFlowProvider>
         </BuilderContextProvider>
       </div>
     </div>


### PR DESCRIPTION
Cette partie se concentre sur la feature type "node on edge drop" qui est standard dans les logiciels d'éditions de nodes.

- [x] Implementation basique
- [x] Mettre l'origine des nodes à [0, 0.5]
- [x]  ~Optimisation UI~
- [ ] ~(optionnel) Ajouter popup de recherche de node lorsque plusieurs options se presentent~
