### PR TITLE
Wiki list

### DIFF
--- a/client/bun.lock
+++ b/client/bun.lock
@@ -60,6 +60,7 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "fake-indexeddb": "^6.1.0",
         "globals": "^16.2.0",
         "jsdom": "^26.1.0",
         "openapi-typescript": "^7.8.0",
@@ -959,7 +960,7 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "commander": ["commander@13.0.0", "", {}, "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ=="],
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
 
@@ -1134,6 +1135,8 @@
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "expect-type": ["expect-type@1.2.2", "", {}, "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.1.0", "", {}, "sha512-gOzajWIhEug/CQHUIxigKT9Zilh5/I6WvUBez6/UdUtT/YVEHM9r572Os8wfvhp7TkmgBtRNdqSM7YoCXWMzZg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1947,6 +1950,8 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@hey-api/openapi-ts/commander": ["commander@13.0.0", "", {}, "sha512-oPYleIY8wmTVzkvQq10AEok6YcTC4sRUBl8F9gVuwchGVUCTbl/vhLTaQqutuuySYOsu8YTgV+OxKc/8Yvx+mQ=="],
+
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
     "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
@@ -2050,8 +2055,6 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tempy/type-fest": ["type-fest@0.16.0", "", {}, "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg=="],
-
-    "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,7 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "fake-indexeddb": "^6.1.0",
     "globals": "^16.2.0",
     "jsdom": "^26.1.0",
     "openapi-typescript": "^7.8.0",

--- a/client/src/design-system/components/base-card.tsx
+++ b/client/src/design-system/components/base-card.tsx
@@ -1,0 +1,49 @@
+import { Card, CardDescription, CardHeader, CardTitle } from "../primitives";
+import { CSSProperties, ReactNode } from "react";
+
+export const BaseCard = ({
+  button,
+  title,
+  description,
+  onClick,
+  backgroundURL,
+}: {
+  backgroundURL: string;
+  title: string;
+  description: string;
+  button?: ReactNode;
+  onClick?: () => void;
+}) => {
+  return (
+    <Card
+      style={{
+        backgroundColor: "black",
+        background: `url('${backgroundURL}')`,
+        backgroundRepeat: "no-repeat",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }}
+      className="group relative h-[225px] w-[275px] shadow-md"
+      onClick={onClick}
+    >
+      <CardHeader>
+        <CardTitle className="max-w-[275px] overflow-hidden rounded-sm bg-gray-50/75 p-2 text-ellipsis whitespace-nowrap">
+          {title}
+        </CardTitle>
+        <CardDescription
+          className="overflow-hidden text-ellipsis text-gray-50"
+          style={
+            {
+              display: "-webkit-box",
+              WebkitLineClamp: "4",
+              WebkitBoxOrient: "vertical",
+            } as CSSProperties
+          }
+        >
+          {description}
+        </CardDescription>
+      </CardHeader>
+      {button ?? null}
+    </Card>
+  );
+};

--- a/client/src/design-system/components/import-modal.tsx
+++ b/client/src/design-system/components/import-modal.tsx
@@ -34,7 +34,7 @@ const ImportPreview = ({
           <p>
             Written by{" "}
             {storyFromImport.story.author?.username ??
-              ANONYMOUS_AUTHOR.username}{" "}
+              ANONYMOUS_AUTHOR.username}
           </p>
           <div className="flex gap-2">
             {storyFromImport.story.genres.map((genre) => (

--- a/client/src/design-system/components/import-modal.tsx
+++ b/client/src/design-system/components/import-modal.tsx
@@ -8,7 +8,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/design-system/primitives";
-import { StoryFromImport } from "@/services/common/import-service";
+import {
+  ANONYMOUS_AUTHOR,
+  StoryFromImport,
+} from "@/services/common/import-service";
 import { ReactNode, useState } from "react";
 import { Badge } from "../primitives/badge";
 import { StoryGenreBadge } from "./story-genre-badge";
@@ -28,7 +31,11 @@ const ImportPreview = ({
         />
         <div>
           <p className="font-semibold">{storyFromImport.story.title}</p>
-          <p>Written by {storyFromImport.story.author.username}</p>
+          <p>
+            Written by{" "}
+            {storyFromImport.story.author?.username ??
+              ANONYMOUS_AUTHOR.username}{" "}
+          </p>
           <div className="flex gap-2">
             {storyFromImport.story.genres.map((genre) => (
               <StoryGenreBadge key={genre} variant={genre} size="sm" />

--- a/client/src/design-system/components/story-card.tsx
+++ b/client/src/design-system/components/story-card.tsx
@@ -1,6 +1,6 @@
 import { Story } from "@/lib/storage/domain";
-import { Card, CardDescription, CardHeader, CardTitle } from "../primitives";
-import { CSSProperties, type JSX } from "react";
+import { BaseCard } from "./base-card";
+import { ReactNode } from "react";
 
 export const StoryCard = ({
   story,
@@ -8,39 +8,16 @@ export const StoryCard = ({
   onClick,
 }: {
   story: Story;
-  button?: JSX.Element;
+  button?: ReactNode;
   onClick?: () => void;
 }) => {
   return (
-    <Card
-      style={{
-        backgroundColor: "black",
-        background: `url('${story.image}')`,
-        backgroundRepeat: "no-repeat",
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-      }}
-      className="group relative h-[225px] w-[275px] shadow-md"
+    <BaseCard
+      backgroundURL={story.image}
+      title={story.title}
+      description={story.description}
+      button={button}
       onClick={onClick}
-    >
-      <CardHeader>
-        <CardTitle className="max-w-[275px] overflow-hidden rounded-sm bg-gray-50/75 p-2 text-ellipsis whitespace-nowrap">
-          {story.title}
-        </CardTitle>
-        <CardDescription
-          className="overflow-hidden text-ellipsis text-gray-50"
-          style={
-            {
-              display: "-webkit-box",
-              WebkitLineClamp: "4",
-              WebkitBoxOrient: "vertical",
-            } as CSSProperties
-          }
-        >
-          {story.description}
-        </CardDescription>
-      </CardHeader>
-      {button ?? null}
-    </Card>
+    />
   );
 };

--- a/client/src/domains/user/user-service.ts
+++ b/client/src/domains/user/user-service.ts
@@ -40,6 +40,7 @@ const _getUserService = ({
           key: response.data.key,
           username: response.data.username,
         });
+        // Add author to wikis as well, maybe use event based pattern ?
       }
 
       return response;

--- a/client/src/domains/user/user-service.ts
+++ b/client/src/domains/user/user-service.ts
@@ -39,9 +39,10 @@ const _getUserService = ({
     username: string;
     key: string;
   }) => {
-    // After authenticating for the first time, we need to set the author field in
+    // After authenticating, we need to set the author field in
     // - stories
     // - wikis
+    // That had an undefined author field
     await Promise.all([
       localRepository.addAuthorToStories({ key, username }),
       wikiService.addAuthorToWikis({ key, username }),

--- a/client/src/domains/user/user-service.ts
+++ b/client/src/domains/user/user-service.ts
@@ -7,13 +7,16 @@ import {
 } from "@/repositories";
 import { WithoutKey } from "@/types";
 import { nanoid } from "nanoid";
+import { getWikiService, WikiServicePort } from "../wiki/wiki-service";
 
 const _getUserService = ({
   localRepository,
   remoteRepository,
+  wikiService,
 }: {
   localRepository: LocalRepositoryPort;
   remoteRepository: RemoteRepositoryPort;
+  wikiService: WikiServicePort;
 }) => {
   const _createLocalUser = async (user: WithoutKey<User>) => {
     const userCount = await localRepository.getUserCount();
@@ -29,18 +32,33 @@ const _getUserService = ({
     return createdUser;
   };
 
+  const _afterAuth = async ({
+    username,
+    key,
+  }: {
+    username: string;
+    key: string;
+  }) => {
+    // After authenticating for the first time, we need to set the author field in
+    // - stories
+    // - wikis
+    await Promise.all([
+      localRepository.addAuthorToStories({ key, username }),
+      wikiService.addAuthorToWikis({ key, username }),
+    ]);
+  };
+
   return {
     login: async (usernameOrEmail: string, password: string) => {
       const response = await remoteRepository.login(usernameOrEmail, password);
 
       if (response.data) {
         _createLocalUser(response.data);
-        // Side effect: once a user is logged in, update all of his or her existing stories' authorKey
-        await localRepository.addAuthorToStories({
-          key: response.data.key,
+        // Side effects
+        _afterAuth({
           username: response.data.username,
+          key: response.data.key,
         });
-        // Add author to wikis as well, maybe use event based pattern ?
       }
 
       return response;
@@ -58,11 +76,8 @@ const _getUserService = ({
 
       if (response.data) {
         const createdUser = await _createLocalUser(response.data);
-        // Side effect: once a user is logged in, update all of his or her existing stories' authorKey
-        localRepository.addAuthorToStories({
-          key: createdUser.key,
-          username: createdUser.username,
-        });
+        // Side effects
+        _afterAuth({ username: createdUser.username, key: createdUser.key });
       }
 
       return response;
@@ -85,4 +100,5 @@ export const getUserService = () =>
   _getUserService({
     localRepository: getLocalRepository(),
     remoteRepository: getRemoteAPIRepository(),
+    wikiService: getWikiService(),
   });

--- a/client/src/domains/wiki/__tests__/wiki-repository.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-repository.test.ts
@@ -22,12 +22,14 @@ describe("wiki repository", () => {
         name: "wiki #1",
         author: { username: TEST_USER.username, key: TEST_USER.key },
         description: "description",
+        type: "created",
       });
       const wiki2 = await testDB.wikis.add({
         image: "photo.fr",
         name: "wiki #2",
         author: undefined,
         description: "vrouuuum",
+        type: "created",
       });
       // Other author
       await testDB.wikis.add({
@@ -38,6 +40,15 @@ describe("wiki repository", () => {
           key: "peter-peter",
         },
         description: "pas mon wiki",
+        type: "created",
+      });
+      // Imported wiki
+      await testDB.wikis.add({
+        image: "wallpaper.fr",
+        name: "wiki #4",
+        author: { username: TEST_USER.username, key: TEST_USER.key },
+        description: "mon wiki, mais importé, pas créé",
+        type: "imported",
       });
 
       const wikis = await repo.getUserWikis(TEST_USER.key);
@@ -48,6 +59,7 @@ describe("wiki repository", () => {
         author: { username: TEST_USER.username, key: TEST_USER.key },
         description: "description",
         key: wiki1,
+        type: "created",
       });
       expect(wikis).toContainEqual({
         image: "photo.fr",
@@ -55,6 +67,7 @@ describe("wiki repository", () => {
         author: undefined,
         description: "vrouuuum",
         key: wiki2,
+        type: "created",
       });
     });
 
@@ -64,6 +77,7 @@ describe("wiki repository", () => {
         name: "wiki #1",
         author: undefined,
         description: "description",
+        type: "created",
       });
       // Other author
       await testDB.wikis.add({
@@ -74,6 +88,7 @@ describe("wiki repository", () => {
           key: "peter-peter",
         },
         description: "pas mon wiki",
+        type: "created",
       });
 
       const wikis = await repo.getUserWikis(undefined);
@@ -84,6 +99,7 @@ describe("wiki repository", () => {
         author: undefined,
         description: "description",
         key: wiki1,
+        type: "created",
       });
     });
   });
@@ -96,6 +112,7 @@ describe("wiki repository", () => {
         author: { username: TEST_USER.username, key: TEST_USER.key },
         description: "description",
         key: "wiki1-key",
+        type: "created",
       },
       {
         image: "photo.fr",
@@ -103,6 +120,7 @@ describe("wiki repository", () => {
         author: undefined,
         description: "vrouuuum",
         key: "wiki2-key",
+        type: "imported",
       },
       {
         image: "avion.png",
@@ -110,6 +128,7 @@ describe("wiki repository", () => {
         author: { username: TEST_USER.username, key: TEST_USER.key },
         description: "pas modifié",
         key: "wiki3-key",
+        type: "created",
       },
     ]);
     expect(await testDB.wikis.toArray()).toHaveLength(3);
@@ -140,6 +159,7 @@ describe("wiki repository", () => {
       author: { username: TEST_USER.username, key: TEST_USER.key },
       description: "une autre description",
       key: "wiki1-key",
+      type: "created",
     });
     expect(wikis).toContainEqual({
       image: "photo.fr",
@@ -147,6 +167,7 @@ describe("wiki repository", () => {
       author: { key: "peter-key", username: "peter_peter" },
       description: "vrouuuum",
       key: "wiki2-key",
+      type: "imported",
     });
     expect(wikis).toContainEqual({
       image: "avion.png",
@@ -154,6 +175,7 @@ describe("wiki repository", () => {
       author: { username: TEST_USER.username, key: TEST_USER.key },
       description: "pas modifié",
       key: "wiki3-key",
+      type: "created",
     });
   });
 

--- a/client/src/domains/wiki/__tests__/wiki-repository.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-repository.test.ts
@@ -15,74 +15,152 @@ describe("wiki repository", () => {
     repo = _getDexieWikiRepository(testDB);
   });
 
-  test("should get all wikis of specified user", async () => {
-    const wiki1 = await testDB.wikis.add({
-      image: "image.fr",
-      name: "wiki #1",
-      author: { username: TEST_USER.username, key: TEST_USER.key },
-      description: "description",
-    });
-    const wiki2 = await testDB.wikis.add({
-      image: "photo.fr",
-      name: "wiki #2",
-      author: undefined,
-      description: "vrouuuum",
-    });
-    // Other author
-    await testDB.wikis.add({
-      image: "wallpaper.fr",
-      name: "wiki #3",
-      author: {
-        username: "peter_peter",
-        key: "peter-peter",
-      },
-      description: "pas mon wiki",
+  describe("get user wikis", () => {
+    test("should get all wikis of specified user", async () => {
+      const wiki1 = await testDB.wikis.add({
+        image: "image.fr",
+        name: "wiki #1",
+        author: { username: TEST_USER.username, key: TEST_USER.key },
+        description: "description",
+      });
+      const wiki2 = await testDB.wikis.add({
+        image: "photo.fr",
+        name: "wiki #2",
+        author: undefined,
+        description: "vrouuuum",
+      });
+      // Other author
+      await testDB.wikis.add({
+        image: "wallpaper.fr",
+        name: "wiki #3",
+        author: {
+          username: "peter_peter",
+          key: "peter-peter",
+        },
+        description: "pas mon wiki",
+      });
+
+      const wikis = await repo.getUserWikis(TEST_USER.key);
+      expect(wikis).toHaveLength(2);
+      expect(wikis).toContainEqual({
+        image: "image.fr",
+        name: "wiki #1",
+        author: { username: TEST_USER.username, key: TEST_USER.key },
+        description: "description",
+        key: wiki1,
+      });
+      expect(wikis).toContainEqual({
+        image: "photo.fr",
+        name: "wiki #2",
+        author: undefined,
+        description: "vrouuuum",
+        key: wiki2,
+      });
     });
 
-    const wikis = await repo.getUserWikis(TEST_USER.key);
-    expect(wikis).toHaveLength(2);
-    expect(wikis).toContainEqual({
-      image: "image.fr",
-      name: "wiki #1",
-      author: { username: TEST_USER.username, key: TEST_USER.key },
-      description: "description",
-      key: wiki1,
-    });
-    expect(wikis).toContainEqual({
-      image: "photo.fr",
-      name: "wiki #2",
-      author: undefined,
-      description: "vrouuuum",
-      key: wiki2,
+    test("should get all wikis without account", async () => {
+      const wiki1 = await testDB.wikis.add({
+        image: "image.fr",
+        name: "wiki #1",
+        author: undefined,
+        description: "description",
+      });
+      // Other author
+      await testDB.wikis.add({
+        image: "wallpaper.fr",
+        name: "wiki #2",
+        author: {
+          username: "peter_peter",
+          key: "peter-peter",
+        },
+        description: "pas mon wiki",
+      });
+
+      const wikis = await repo.getUserWikis(undefined);
+      expect(wikis).toHaveLength(1);
+      expect(wikis).toContainEqual({
+        image: "image.fr",
+        name: "wiki #1",
+        author: undefined,
+        description: "description",
+        key: wiki1,
+      });
     });
   });
 
-  test("should get all wikis without account", async () => {
-    const wiki1 = await testDB.wikis.add({
-      image: "image.fr",
-      name: "wiki #1",
-      author: undefined,
-      description: "description",
-    });
-    // Other author
-    await testDB.wikis.add({
-      image: "wallpaper.fr",
-      name: "wiki #2",
-      author: {
-        username: "peter_peter",
-        key: "peter-peter",
+  test("should update wikis correctly", async () => {
+    await testDB.wikis.bulkAdd([
+      {
+        image: "image.fr",
+        name: "wiki #1",
+        author: { username: TEST_USER.username, key: TEST_USER.key },
+        description: "description",
+        key: "wiki1-key",
       },
-      description: "pas mon wiki",
-    });
+      {
+        image: "photo.fr",
+        name: "wiki #2",
+        author: undefined,
+        description: "vrouuuum",
+        key: "wiki2-key",
+      },
+      {
+        image: "avion.png",
+        name: "wiki #3",
+        author: { username: TEST_USER.username, key: TEST_USER.key },
+        description: "pas modifié",
+        key: "wiki3-key",
+      },
+    ]);
+    expect(await testDB.wikis.toArray()).toHaveLength(3);
 
-    const wikis = await repo.getUserWikis(undefined);
-    expect(wikis).toHaveLength(1);
+    await repo.bulkUpdate([
+      {
+        key: "wiki1-key",
+        description: "une autre description",
+        name: "coucou",
+      },
+      {
+        key: "wiki2-key",
+        author: { key: "peter-key", username: "peter_peter" },
+      },
+      {
+        key: "wiki4-key", // Does not exist
+        name: "tutu",
+      },
+      { key: "wiki3-key" },
+    ]);
+
+    const wikis = await testDB.wikis.toArray();
+
+    expect(wikis).toHaveLength(3);
     expect(wikis).toContainEqual({
       image: "image.fr",
-      name: "wiki #1",
-      author: undefined,
-      description: "description",
-      key: wiki1,
+      name: "coucou",
+      author: { username: TEST_USER.username, key: TEST_USER.key },
+      description: "une autre description",
+      key: "wiki1-key",
     });
+    expect(wikis).toContainEqual({
+      image: "photo.fr",
+      name: "wiki #2",
+      author: { key: "peter-key", username: "peter_peter" },
+      description: "vrouuuum",
+      key: "wiki2-key",
+    });
+    expect(wikis).toContainEqual({
+      image: "avion.png",
+      name: "wiki #3",
+      author: { username: TEST_USER.username, key: TEST_USER.key },
+      description: "pas modifié",
+      key: "wiki3-key",
+    });
+  });
+
+  test("should not authorize same wiki multiple times", async () => {
+    expect(
+      async () =>
+        await repo.bulkUpdate([{ key: "a" }, { key: "b" }, { key: "a" }]),
+    ).rejects.toThrowError("Each wiki can only be present once in the input");
   });
 });

--- a/client/src/domains/wiki/__tests__/wiki-repository.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-repository.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  _getDexieWikiRepository,
+  WikiRepositoryPort,
+} from "../wiki-repository";
+import { getTestDatabase, TEST_USER } from "@/lib/storage/dexie/test-db";
+import { Database } from "@/lib/storage/dexie/dexie-db";
+
+describe("wiki repository", () => {
+  let repo: WikiRepositoryPort;
+  let testDB: Database;
+
+  beforeEach(async () => {
+    testDB = await getTestDatabase();
+    repo = _getDexieWikiRepository(testDB);
+  });
+
+  test("should get all wikis of specified user", async () => {
+    const wiki1 = await testDB.wikis.add({
+      image: "image.fr",
+      name: "wiki #1",
+      author: { username: TEST_USER.username, key: TEST_USER.key },
+      description: "description",
+    });
+    const wiki2 = await testDB.wikis.add({
+      image: "photo.fr",
+      name: "wiki #2",
+      author: undefined,
+      description: "vrouuuum",
+    });
+    // Other author
+    await testDB.wikis.add({
+      image: "wallpaper.fr",
+      name: "wiki #3",
+      author: {
+        username: "peter_peter",
+        key: "peter-peter",
+      },
+      description: "pas mon wiki",
+    });
+
+    const wikis = await repo.getUserWikis(TEST_USER.key);
+    expect(wikis).toHaveLength(2);
+    expect(wikis).toContainEqual({
+      image: "image.fr",
+      name: "wiki #1",
+      author: { username: TEST_USER.username, key: TEST_USER.key },
+      description: "description",
+      key: wiki1,
+    });
+    expect(wikis).toContainEqual({
+      image: "photo.fr",
+      name: "wiki #2",
+      author: undefined,
+      description: "vrouuuum",
+      key: wiki2,
+    });
+  });
+
+  test("should get all wikis without account", async () => {
+    const wiki1 = await testDB.wikis.add({
+      image: "image.fr",
+      name: "wiki #1",
+      author: undefined,
+      description: "description",
+    });
+    // Other author
+    await testDB.wikis.add({
+      image: "wallpaper.fr",
+      name: "wiki #2",
+      author: {
+        username: "peter_peter",
+        key: "peter-peter",
+      },
+      description: "pas mon wiki",
+    });
+
+    const wikis = await repo.getUserWikis(undefined);
+    expect(wikis).toHaveLength(1);
+    expect(wikis).toContainEqual({
+      image: "image.fr",
+      name: "wiki #1",
+      author: undefined,
+      description: "description",
+      key: wiki1,
+    });
+  });
+});

--- a/client/src/domains/wiki/__tests__/wiki-service.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-service.test.ts
@@ -8,36 +8,78 @@ import { _getWikiService } from "../wiki-service";
 import { TEST_USER } from "@/lib/storage/dexie/test-db";
 
 describe("wiki service", () => {
-  test("should return user's wikis", async () => {
-    const repository = getStubWikiRepository();
+  describe("get all wikis", () => {
+    test("should return user's wikis", async () => {
+      const repository = getStubWikiRepository();
 
-    repository.getUserWikis = vi.fn((userKey) => {
-      expect(userKey).toStrictEqual(TEST_USER.key);
+      repository.getUserWikis = vi.fn((userKey) => {
+        expect(userKey).toStrictEqual(TEST_USER.key);
 
-      return Promise.resolve([
-        {
-          image: "image.fr",
-          name: "wiki #1",
-          author: { username: "bob_bidou", key: "userKey" },
-          description: "description",
-          key: "key",
-        },
-      ]);
+        return Promise.resolve([
+          {
+            image: "image.fr",
+            name: "wiki #1",
+            author: { username: "bob_bidou", key: "userKey" },
+            description: "description",
+            key: "key",
+          },
+        ]);
+      });
+
+      const svc = _getWikiService({
+        repository,
+        context: getWikiServiceTestContext(),
+      });
+      const wikis = await svc.getAllWikis();
+
+      expect(wikis).toHaveLength(1);
+      expect(wikis).toContainEqual({
+        image: "image.fr",
+        name: "wiki #1",
+        author: { username: "bob_bidou", key: "userKey" },
+        description: "description",
+        key: "key",
+      });
     });
+  });
 
-    const svc = _getWikiService({
-      repository,
-      context: getWikiServiceTestContext(),
-    });
-    const wikis = await svc.getAllWikis();
+  describe("add author to wikis", () => {
+    test("should update wikis", async () => {
+      const repository = getStubWikiRepository();
+      repository.getUserWikis = vi.fn((userKey) => {
+        expect(userKey).toStrictEqual(TEST_USER.key);
 
-    expect(wikis).toHaveLength(1);
-    expect(wikis).toContainEqual({
-      image: "image.fr",
-      name: "wiki #1",
-      author: { username: "bob_bidou", key: "userKey" },
-      description: "description",
-      key: "key",
+        return Promise.resolve([
+          {
+            image: "image.fr",
+            name: "wiki #1",
+            author: { username: "bob_bidou", key: "userKey" },
+            description: "description",
+            key: "key-1",
+          },
+          {
+            image: "photo.fr",
+            name: "wiki #2",
+            author: undefined,
+            description: "other description",
+            key: "key-2",
+          },
+        ]);
+      });
+
+      repository.bulkUpdate = vi.fn((payload) => {
+        expect(payload).toStrictEqual([
+          { key: "key-2", author: { username: "bob_bidou", key: "bob-key" } },
+        ]);
+
+        return Promise.resolve();
+      });
+
+      const svc = _getWikiService({
+        repository,
+        context: getWikiServiceTestContext(),
+      });
+      await svc.addAuthorToWikis({ username: "bob_bidou", key: "bob-key" });
     });
   });
 });

--- a/client/src/domains/wiki/__tests__/wiki-service.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-service.test.ts
@@ -22,6 +22,7 @@ describe("wiki service", () => {
             author: { username: "bob_bidou", key: "userKey" },
             description: "description",
             key: "key",
+            type: "created" as const,
           },
         ]);
       });
@@ -56,6 +57,7 @@ describe("wiki service", () => {
             author: { username: "bob_bidou", key: "userKey" },
             description: "description",
             key: "key-1",
+            type: "created" as const,
           },
           {
             image: "photo.fr",
@@ -63,6 +65,15 @@ describe("wiki service", () => {
             author: undefined,
             description: "other description",
             key: "key-2",
+            type: "created" as const,
+          },
+          {
+            image: "photo.fr",
+            name: "Imported wiki",
+            author: undefined,
+            description: "tutu",
+            key: "key-3",
+            type: "imported" as const,
           },
         ]);
       });

--- a/client/src/domains/wiki/__tests__/wiki-service.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-service.test.ts
@@ -1,0 +1,43 @@
+import { describe } from "node:test";
+import { expect, test, vi } from "vitest";
+import {
+  getStubWikiRepository,
+  getWikiServiceTestContext,
+} from "../stubs/stub-wiki-repository";
+import { _getWikiService } from "../wiki-service";
+import { TEST_USER } from "@/lib/storage/dexie/test-db";
+
+describe("wiki service", () => {
+  test("should return user's wikis", async () => {
+    const repository = getStubWikiRepository();
+
+    repository.getUserWikis = vi.fn((userKey) => {
+      expect(userKey).toStrictEqual(TEST_USER.key);
+
+      return Promise.resolve([
+        {
+          image: "image.fr",
+          name: "wiki #1",
+          author: { username: "bob_bidou", key: "userKey" },
+          description: "description",
+          key: "key",
+        },
+      ]);
+    });
+
+    const svc = _getWikiService({
+      repository,
+      context: getWikiServiceTestContext(),
+    });
+    const wikis = await svc.getAllWikis();
+
+    expect(wikis).toHaveLength(1);
+    expect(wikis).toContainEqual({
+      image: "image.fr",
+      name: "wiki #1",
+      author: { username: "bob_bidou", key: "userKey" },
+      description: "description",
+      key: "key",
+    });
+  });
+});

--- a/client/src/domains/wiki/__tests__/wiki-service.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-service.test.ts
@@ -40,6 +40,7 @@ describe("wiki service", () => {
         author: { username: "bob_bidou", key: "userKey" },
         description: "description",
         key: "key",
+        type: "created",
       });
     });
   });

--- a/client/src/domains/wiki/stubs/stub-wiki-repository.ts
+++ b/client/src/domains/wiki/stubs/stub-wiki-repository.ts
@@ -4,7 +4,7 @@ import { WikiServiceContext } from "../wiki-service";
 import { TEST_USER } from "@/lib/storage/dexie/test-db";
 
 export const getWikiServiceTestContext = (): WikiServiceContext => ({
-  userKey: TEST_USER.key,
+  getUser: () => Promise.resolve(TEST_USER),
 });
 
 export const getStubWikiRepository = (): WikiRepositoryPort => ({

--- a/client/src/domains/wiki/stubs/stub-wiki-repository.ts
+++ b/client/src/domains/wiki/stubs/stub-wiki-repository.ts
@@ -9,4 +9,5 @@ export const getWikiServiceTestContext = (): WikiServiceContext => ({
 
 export const getStubWikiRepository = (): WikiRepositoryPort => ({
   getUserWikis: vi.fn(async () => Promise.resolve([])),
+  bulkUpdate: vi.fn(async () => Promise.resolve()),
 });

--- a/client/src/domains/wiki/stubs/stub-wiki-repository.ts
+++ b/client/src/domains/wiki/stubs/stub-wiki-repository.ts
@@ -1,0 +1,12 @@
+import { vi } from "vitest";
+import { WikiRepositoryPort } from "../wiki-repository";
+import { WikiServiceContext } from "../wiki-service";
+import { TEST_USER } from "@/lib/storage/dexie/test-db";
+
+export const getWikiServiceTestContext = (): WikiServiceContext => ({
+  userKey: TEST_USER.key,
+});
+
+export const getStubWikiRepository = (): WikiRepositoryPort => ({
+  getUserWikis: vi.fn(async () => Promise.resolve([])),
+});

--- a/client/src/domains/wiki/wiki-repository.ts
+++ b/client/src/domains/wiki/wiki-repository.ts
@@ -1,0 +1,20 @@
+import { Database, db } from "@/lib/storage/dexie/dexie-db";
+import { Wiki } from "@/lib/storage/domain";
+
+export type WikiRepositoryPort = {
+  getUserWikis: (userKey: string | undefined) => Promise<Wiki[]>;
+};
+
+export const _getDexieWikiRepository = (db: Database): WikiRepositoryPort => {
+  return {
+    getUserWikis: async (userKey) => {
+      return db.wikis
+        .filter((wiki) => [userKey, undefined].includes(wiki.author?.key))
+        .toArray();
+    },
+  };
+};
+
+export const getDexieWikiRepository = (): WikiRepositoryPort => {
+  return _getDexieWikiRepository(db);
+};

--- a/client/src/domains/wiki/wiki-repository.ts
+++ b/client/src/domains/wiki/wiki-repository.ts
@@ -12,7 +12,11 @@ export const _getDexieWikiRepository = (db: Database): WikiRepositoryPort => {
   return {
     getUserWikis: async (userKey) => {
       return await db.wikis
-        .filter((wiki) => [userKey, undefined].includes(wiki.author?.key))
+        .filter(
+          (wiki) =>
+            [userKey, undefined].includes(wiki.author?.key) &&
+            wiki.type === "created",
+        )
         .toArray();
     },
     bulkUpdate: async (wikis) => {

--- a/client/src/domains/wiki/wiki-repository.ts
+++ b/client/src/domains/wiki/wiki-repository.ts
@@ -3,14 +3,27 @@ import { Wiki } from "@/lib/storage/domain";
 
 export type WikiRepositoryPort = {
   getUserWikis: (userKey: string | undefined) => Promise<Wiki[]>;
+  bulkUpdate: (
+    wikis: ({ key: string } & Partial<Omit<Wiki, "key">>)[],
+  ) => Promise<void>;
 };
 
 export const _getDexieWikiRepository = (db: Database): WikiRepositoryPort => {
   return {
     getUserWikis: async (userKey) => {
-      return db.wikis
+      return await db.wikis
         .filter((wiki) => [userKey, undefined].includes(wiki.author?.key))
         .toArray();
+    },
+    bulkUpdate: async (wikis) => {
+      const uniqueKeys = new Set(wikis.map(({ key }) => key));
+      if (uniqueKeys.size !== wikis.length) {
+        throw new Error("Each wiki can only be present once in the input");
+      }
+
+      await db.wikis.bulkUpdate(
+        wikis.map(({ key, ...changes }) => ({ key, changes })),
+      );
     },
   };
 };

--- a/client/src/domains/wiki/wiki-service.ts
+++ b/client/src/domains/wiki/wiki-service.ts
@@ -1,0 +1,34 @@
+import { Wiki } from "@/lib/storage/domain";
+import { getDexieWikiRepository, WikiRepositoryPort } from "./wiki-repository";
+import { getUser } from "@/lib/auth";
+
+export type WikiServicePort = {
+  getAllWikis: () => Promise<Wiki[]>;
+};
+
+export type WikiServiceContext = {
+  userKey: string | undefined;
+};
+
+export const _getWikiService = ({
+  repository,
+  context,
+}: {
+  repository: WikiRepositoryPort;
+  context: WikiServiceContext;
+}): WikiServicePort => {
+  return {
+    getAllWikis: async () => {
+      return repository.getUserWikis(context.userKey);
+    },
+  };
+};
+
+export const getWikiService = async () => {
+  return _getWikiService({
+    repository: getDexieWikiRepository(),
+    context: {
+      userKey: (await getUser())?.key,
+    },
+  });
+};

--- a/client/src/domains/wiki/wiki-service.ts
+++ b/client/src/domains/wiki/wiki-service.ts
@@ -31,7 +31,7 @@ export const _getWikiService = ({
 
     addAuthorToWikis: async ({ username, key }) => {
       const wikis = (await getAllWikis()).filter(
-        (wiki) => wiki.author === undefined,
+        (wiki) => wiki.author === undefined && wiki.type === "created",
       );
       await repository.bulkUpdate(
         wikis.map((wiki) => ({ key: wiki.key, author: { username, key } })),

--- a/client/src/domains/wiki/wiki-service.ts
+++ b/client/src/domains/wiki/wiki-service.ts
@@ -1,4 +1,4 @@
-import { Wiki } from "@/lib/storage/domain";
+import { User, Wiki } from "@/lib/storage/domain";
 import { getDexieWikiRepository, WikiRepositoryPort } from "./wiki-repository";
 import { getUser } from "@/lib/auth";
 
@@ -7,7 +7,7 @@ export type WikiServicePort = {
 };
 
 export type WikiServiceContext = {
-  userKey: string | undefined;
+  getUser: () => Promise<User | null>;
 };
 
 export const _getWikiService = ({
@@ -19,7 +19,8 @@ export const _getWikiService = ({
 }): WikiServicePort => {
   return {
     getAllWikis: async () => {
-      return repository.getUserWikis(context.userKey);
+      const user = await context.getUser();
+      return repository.getUserWikis(user?.key);
     },
   };
 };
@@ -27,8 +28,6 @@ export const _getWikiService = ({
 export const getWikiService = async () => {
   return _getWikiService({
     repository: getDexieWikiRepository(),
-    context: {
-      userKey: (await getUser())?.key,
-    },
+    context: { getUser },
   });
 };

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -5,7 +5,7 @@ export const getUser = async () => {
   const users = await db.user.toArray();
   if (users.length > 1) {
     throw new Error(
-      "There should always be maximum one user in local database",
+      "There should always be at most one user in the local database",
     );
   }
   return (users?.[0] ?? null) as User | null;

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,0 +1,12 @@
+import { db } from "./storage/dexie/dexie-db";
+import { User } from "./storage/domain";
+
+export const getUser = async () => {
+  const users = await db.user.toArray();
+  if (users.length > 1) {
+    throw new Error(
+      "There should always be maximum one user in local database",
+    );
+  }
+  return (users?.[0] ?? null) as User | null;
+};

--- a/client/src/lib/storage/dexie/dexie-db.ts
+++ b/client/src/lib/storage/dexie/dexie-db.ts
@@ -15,7 +15,7 @@ export type Database = Dexie & Tables;
 
 export const db = new Dexie("story-builder") as Database;
 
-export const tables: Record<keyof Tables, string> = {
+const tables: Record<keyof Tables, string> = {
   user: "&key, username, email",
   stories:
     "&key, firstSceneKey, title, description, image, status, genres, publicationDate, creationDate, author, finished",

--- a/client/src/lib/storage/dexie/dexie-db.ts
+++ b/client/src/lib/storage/dexie/dexie-db.ts
@@ -1,69 +1,74 @@
 import Dexie, { type EntityTable } from "dexie";
 import { nanoid } from "nanoid";
-import { User, Story, Scene, StoryProgress } from "../domain";
+import { User, Story, Scene, StoryProgress, Wiki } from "../domain";
 import { DEMO_IMPORTED_STORY, DEMO_SCENES, DEMO_STORY } from "./seed";
 import { getLibraryService } from "@/domains/game/library-service";
 
-// TODO: move this file to a more appropriate location
 type Tables = {
   user: EntityTable<User, "key">;
   stories: EntityTable<Story, "key">;
   scenes: EntityTable<Scene, "key">;
   storyProgresses: EntityTable<StoryProgress, "key">;
+  wikis: EntityTable<Wiki, "key">;
 };
+export type Database = Dexie & Tables;
 
-export const db = new Dexie("story-builder") as Dexie & Tables;
+export const db = new Dexie("story-builder") as Database;
 
-const tables: Record<keyof Tables, string> = {
+export const tables: Record<keyof Tables, string> = {
   user: "&key, username, email",
   stories:
     "&key, firstSceneKey, title, description, image, status, genres, publicationDate, creationDate, author, finished",
   scenes: "&key, storyKey, title, content, actions, builderParams",
   storyProgresses:
     "&key, storyKey, userKey, currentSceneKey, character, inventory, history, lastPlayedAt",
+  wikis: "&key, userKey",
 };
-
-db.version(1).stores(tables);
-
 export const TABLE_NAMES = Object.keys(tables);
 
-db.on("populate", async (_transaction) => {
-  // Add story to builder
-  await db.stories.add(DEMO_STORY);
-  await db.scenes.bulkAdd(DEMO_SCENES);
+export const createDb = (db: Database) => {
+  db.version(1).stores(tables);
 
-  // Add story to library
-  await getLibraryService().importStory(DEMO_IMPORTED_STORY);
-});
+  db.on("populate", async () => {
+    // Add story to builder
+    await db.stories.add(DEMO_STORY);
+    await db.scenes.bulkAdd(DEMO_SCENES);
 
-// Register nanoid middleware
-db.use({
-  stack: "dbcore",
-  name: "primary-key-nanoid-mw",
-  create: (core) => ({
-    ...core,
-    table: (tableName) => {
-      const table = core.table(tableName);
+    // Add story to library
+    await getLibraryService().importStory(DEMO_IMPORTED_STORY);
+  });
 
-      return {
-        ...table,
-        mutate: (req) => {
-          if (req.type === "add") {
-            // For every insertion in the database, generate a nanoid and use it as the primary key
-            req.values.forEach((value) => {
-              if (!value.key) {
-                Dexie.setByKeyPath(
-                  value,
-                  table.schema.primaryKey.keyPath!,
-                  nanoid(),
-                );
-              }
-            });
-          }
+  // Register nanoid middleware
+  db.use({
+    stack: "dbcore",
+    name: "primary-key-nanoid-mw",
+    create: (core) => ({
+      ...core,
+      table: (tableName) => {
+        const table = core.table(tableName);
 
-          return table.mutate(req);
-        },
-      };
-    },
-  }),
-});
+        return {
+          ...table,
+          mutate: (req) => {
+            if (req.type === "add") {
+              // For every insertion in the database, generate a nanoid and use it as the primary key
+              req.values.forEach((value) => {
+                if (!value.key) {
+                  Dexie.setByKeyPath(
+                    value,
+                    table.schema.primaryKey.keyPath!,
+                    nanoid(),
+                  );
+                }
+              });
+            }
+
+            return table.mutate(req);
+          },
+        };
+      },
+    }),
+  });
+};
+
+createDb(db);

--- a/client/src/lib/storage/dexie/test-db.ts
+++ b/client/src/lib/storage/dexie/test-db.ts
@@ -1,0 +1,23 @@
+import Dexie from "dexie";
+import { createDb, Database } from "./dexie-db";
+import { IDBKeyRange, IDBFactory } from "fake-indexeddb";
+import { User } from "../domain";
+
+export const TEST_USER: User = {
+  email: "test@gmail.com",
+  username: "test-user",
+  key: "test-user-key",
+};
+
+export const getTestDatabase = async () => {
+  const indexedDB = new IDBFactory();
+  const testDB = new Dexie("test-sb", {
+    indexedDB,
+    IDBKeyRange,
+  }) as Database;
+
+  createDb(testDB);
+  await testDB.user.add(TEST_USER);
+
+  return testDB;
+};

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -80,6 +80,7 @@ export type StoryProgress = {
 export type Wiki = {
   key: string;
   author?: Author;
+  type: "imported" | "created";
   name: string;
   description?: string;
   image: string;

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -26,12 +26,14 @@ export type User = {
 export const STORY_TYPE = ["builder", "published", "imported"] as const;
 export type StoryType = (typeof STORY_TYPE)[number];
 
+type Author = {
+  key: string;
+  username: string;
+};
+
 type StoryBase = {
   key: string;
-  author?: {
-    key: string;
-    username: string;
-  };
+  author?: Author;
   title: string;
   description: string;
   image: string;
@@ -75,5 +77,19 @@ export type StoryProgress = {
   finished?: boolean;
 };
 
-export const ENTITIES = ["story", "scene", "user", "story-progress"] as const;
+export type Wiki = {
+  key: string;
+  author?: Author;
+  name: string;
+  description?: string;
+  image: string;
+};
+
+export const ENTITIES = [
+  "story",
+  "scene",
+  "user",
+  "story-progress",
+  "wiki",
+] as const;
 export type Entity = (typeof ENTITIES)[number];

--- a/client/src/navbar/desktop-navbar.tsx
+++ b/client/src/navbar/desktop-navbar.tsx
@@ -48,6 +48,11 @@ export const DesktopNavbar = ({
             Builder
           </NavButton>
         </Link>
+        <Link to="/wikis" className="block">
+          <NavButton isCurrentState={pathname.includes("wikis")}>
+            Wikis
+          </NavButton>
+        </Link>
         <Link to="/about" className="block">
           <NavButton isCurrentState={pathname === "/about"}>About</NavButton>
         </Link>

--- a/client/src/navbar/mobile-navbar.tsx
+++ b/client/src/navbar/mobile-navbar.tsx
@@ -26,6 +26,7 @@ import {
   LogOutIcon,
   MenuIcon,
   NetworkIcon,
+  ScrollTextIcon,
 } from "lucide-react";
 import { AuthModalForm } from "@/components/auth-modal-form";
 import { toast } from "sonner";
@@ -192,6 +193,14 @@ export const MobileNavbar = ({
               icon={<NetworkIcon size="20px" />}
             >
               Builder
+            </NavButton>
+          </Link>
+          <Link to="/wikis" className="block">
+            <NavButton
+              isCurrentState={pathname.includes("wikis")}
+              icon={<ScrollTextIcon size="20px" />}
+            >
+              Wikis
             </NavButton>
           </Link>
           <Link to="/about" className="block">

--- a/client/src/repositories/indexed-db-repository.ts
+++ b/client/src/repositories/indexed-db-repository.ts
@@ -152,7 +152,9 @@ const indexedDBRepository: LocalRepositoryPort = {
   addAuthorToStories: async (author) => {
     db.transaction("readwrite", "stories", async () => {
       const storiesToUpdate = (await db.stories
-        .filter((story) => story.author === undefined)
+        .filter(
+          (story) => story.author === undefined && story.type === "builder",
+        )
         .keys()) as string[];
 
       const payload = storiesToUpdate.map((key) => ({

--- a/client/src/repositories/indexed-db-repository.ts
+++ b/client/src/repositories/indexed-db-repository.ts
@@ -13,6 +13,7 @@ const entityToDexieTableAdapter = (entity: Entity) => {
     scene: "scenes",
     user: "user",
     "story-progress": "storyProgresses",
+    wiki: "wikis",
   };
 
   return mapping[entity];

--- a/client/src/routeTree.gen.ts
+++ b/client/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as WikisIndexRouteImport } from './routes/wikis/index'
 import { Route as LibraryIndexRouteImport } from './routes/library/index'
 import { Route as LibraryStoryKeyRouteImport } from './routes/library/$storyKey'
 import { Route as BuilderStoriesRouteImport } from './routes/builder/stories'
@@ -26,6 +27,11 @@ const AboutRoute = AboutRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WikisIndexRoute = WikisIndexRouteImport.update({
+  id: '/wikis/',
+  path: '/wikis/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LibraryIndexRoute = LibraryIndexRouteImport.update({
@@ -66,6 +72,7 @@ export interface FileRoutesByFullPath {
   '/builder/stories': typeof BuilderStoriesRoute
   '/library/$storyKey': typeof LibraryStoryKeyRoute
   '/library': typeof LibraryIndexRoute
+  '/wikis': typeof WikisIndexRoute
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
@@ -76,6 +83,7 @@ export interface FileRoutesByTo {
   '/builder/stories': typeof BuilderStoriesRoute
   '/library/$storyKey': typeof LibraryStoryKeyRoute
   '/library': typeof LibraryIndexRoute
+  '/wikis': typeof WikisIndexRoute
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
@@ -87,6 +95,7 @@ export interface FileRoutesById {
   '/builder/stories': typeof BuilderStoriesRoute
   '/library/$storyKey': typeof LibraryStoryKeyRoute
   '/library/': typeof LibraryIndexRoute
+  '/wikis/': typeof WikisIndexRoute
   '/game/$gameKey/$sceneKey': typeof GameGameKeySceneKeyRoute
   '/game/test/$gameKey/$sceneKey': typeof GameTestGameKeySceneKeyRoute
 }
@@ -99,6 +108,7 @@ export interface FileRouteTypes {
     | '/builder/stories'
     | '/library/$storyKey'
     | '/library'
+    | '/wikis'
     | '/game/$gameKey/$sceneKey'
     | '/game/test/$gameKey/$sceneKey'
   fileRoutesByTo: FileRoutesByTo
@@ -109,6 +119,7 @@ export interface FileRouteTypes {
     | '/builder/stories'
     | '/library/$storyKey'
     | '/library'
+    | '/wikis'
     | '/game/$gameKey/$sceneKey'
     | '/game/test/$gameKey/$sceneKey'
   id:
@@ -119,6 +130,7 @@ export interface FileRouteTypes {
     | '/builder/stories'
     | '/library/$storyKey'
     | '/library/'
+    | '/wikis/'
     | '/game/$gameKey/$sceneKey'
     | '/game/test/$gameKey/$sceneKey'
   fileRoutesById: FileRoutesById
@@ -130,6 +142,7 @@ export interface RootRouteChildren {
   BuilderStoriesRoute: typeof BuilderStoriesRoute
   LibraryStoryKeyRoute: typeof LibraryStoryKeyRoute
   LibraryIndexRoute: typeof LibraryIndexRoute
+  WikisIndexRoute: typeof WikisIndexRoute
   GameGameKeySceneKeyRoute: typeof GameGameKeySceneKeyRoute
   GameTestGameKeySceneKeyRoute: typeof GameTestGameKeySceneKeyRoute
 }
@@ -148,6 +161,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/wikis/': {
+      id: '/wikis/'
+      path: '/wikis'
+      fullPath: '/wikis'
+      preLoaderRoute: typeof WikisIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/library/': {
@@ -202,6 +222,7 @@ const rootRouteChildren: RootRouteChildren = {
   BuilderStoriesRoute: BuilderStoriesRoute,
   LibraryStoryKeyRoute: LibraryStoryKeyRoute,
   LibraryIndexRoute: LibraryIndexRoute,
+  WikisIndexRoute: WikisIndexRoute,
   GameGameKeySceneKeyRoute: GameGameKeySceneKeyRoute,
   GameTestGameKeySceneKeyRoute: GameTestGameKeySceneKeyRoute,
 }

--- a/client/src/routes/wikis/index.tsx
+++ b/client/src/routes/wikis/index.tsx
@@ -1,0 +1,24 @@
+import { BackdropLoader, ErrorMessage } from "@/design-system/components";
+import { getWikiService } from "@/domains/wiki/wiki-service";
+import { WikiList } from "@/wikis/wiki-list";
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+
+const RouteComponent = () => {
+  const { data: wikis } = useQuery({
+    queryKey: ["WIKIS"],
+    queryFn: async () => (await getWikiService()).getAllWikis(),
+  });
+
+  if (wikis === undefined) return <BackdropLoader />;
+
+  return wikis ? (
+    <WikiList wikis={wikis} />
+  ) : (
+    <ErrorMessage>Could not get wikis</ErrorMessage>
+  );
+};
+
+export const Route = createFileRoute("/wikis/")({
+  component: RouteComponent,
+});

--- a/client/src/services/common/__tests__/import-service.test.ts
+++ b/client/src/services/common/__tests__/import-service.test.ts
@@ -112,7 +112,7 @@ describe("import-service", () => {
   });
 
   describe("createStory", () => {
-    it("should create story", async () => {
+    it("should create story (imported)", async () => {
       const result = await importService.createStory({
         story: parsed,
         type: "imported",
@@ -131,6 +131,36 @@ describe("import-service", () => {
         author: {
           username: "author",
           key: "author-key",
+        },
+      });
+
+      expect(result).toStrictEqual({
+        data: BASIC_STORY, // From repository stub
+      });
+    });
+
+    it("should create story with anonymous author", async () => {
+      const result = await importService.createStory({
+        story: {
+          story: { ...parsed.story, author: undefined },
+          scenes: parsed.scenes,
+        },
+        type: "imported",
+      });
+
+      expect(localRepository.createStory).toHaveBeenCalledWith({
+        type: "imported",
+        originalStoryKey: "bloup",
+        title: "The Great Journey To The Green River",
+        description: "A wonderful epic tale through the world of Penthetir. ",
+        image:
+          "https://b2-backblaze-stackpath.b-cdn.net/2178699/c5jpvq_12e7c09178a6a75a5979d117f779bb07ff07f8f9.jpg",
+        genres: ["adventure" as const, "fantasy" as const],
+        creationDate: importedStory.creationDate,
+        firstSceneKey: TEMPORARY_NULL_KEY,
+        author: {
+          username: "Anonymous Author",
+          key: "ANONYMOUS_AUTHOR_KEY",
         },
       });
 

--- a/client/src/services/common/import-service.ts
+++ b/client/src/services/common/import-service.ts
@@ -11,13 +11,19 @@ import { getLocalRepository, LocalRepositoryPort } from "@/repositories";
 import { WithoutKey } from "@/types";
 import { contentSchema } from "@/lib/scene-content";
 
+export const ANONYMOUS_AUTHOR = {
+  key: "ANONYMOUS_AUTHOR_KEY",
+  username: "Anonymous Author",
+};
+
 export const TEMPORARY_NULL_KEY = "TEMPORARY_NULL_KEY";
 
 export const storyFromImportSchema = z.object({
   story: z.object(
     {
-      description: z.string({ message: "Description is required" }),
       key: z.string({ message: "storyKey is required" }),
+      title: z.string({ message: "Title is required" }),
+      description: z.string({ message: "Description is required" }),
       firstSceneKey: z.string({ message: "FirstSceneKey is required" }),
       creationDate: z
         .string({ message: "creationDate is required" })
@@ -27,15 +33,16 @@ export const storyFromImportSchema = z.object({
         .transform((val) => new Date(val))
         .optional(),
       genres: z.array(z.enum(STORY_GENRES)),
-      author: z.object({
-        username: z.string(),
-        key: z.string(),
-      }),
+      author: z
+        .object({
+          username: z.string(),
+          key: z.string(),
+        })
+        .optional(),
       image: z.string().url({ message: "Image has to be a valid URL" }),
       type: z.enum(STORY_TYPE, {
         message: "Type has to be a valid StoryType",
       }),
-      title: z.string({ message: "Title is required" }),
     },
     { message: "Story is required" },
   ),
@@ -174,6 +181,8 @@ export const _getImportService = ({
         storyPayload.author = user
           ? { username: user.username, key: user.key }
           : undefined;
+      } else if (!storyPayload.author) {
+        storyPayload.author = ANONYMOUS_AUTHOR;
       }
 
       const story = await localRepository.createStory(storyPayload);

--- a/client/src/wikis/wiki-list.tsx
+++ b/client/src/wikis/wiki-list.tsx
@@ -1,0 +1,30 @@
+import { Wiki } from "@/lib/storage/domain";
+import { Title } from "@/design-system/components";
+import { BaseCard } from "@/design-system/components/base-card";
+
+export const WikiList = ({ wikis }: { wikis: Wiki[] }) => {
+  return (
+    <div className="flex flex-col items-center space-y-8 px-16 py-8 sm:items-start sm:px-32">
+      <Title variant="secondary">Wikis</Title>
+      <p className="text-muted-foreground">
+        All the wikis you've created are here.
+      </p>
+      {wikis.length ? (
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap">
+          {wikis.map((wiki) => {
+            return (
+              <BaseCard
+                key={wiki.key}
+                title={wiki.name}
+                description={wiki.description ?? ""}
+                backgroundURL={wiki.image}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <p>No wikis...</p>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
- Ajout de la table, service et repository pour gérer les wikis
- Nouvelle route `/wikis` + page de liste qui affiche les wikis 
- Mise à jour des auteurs des wikis quand un·e user se connecte/crée un compte (pour gérer le fait qu'on peut en créer sans compte (`author` = `undefined`))
- Rend le champ `author` optionnel dans l'import JSON => utiliser un user statique anonyme à la place 
- Tests unitaires sur tout ce bazar, notamment les premiers tests unitaires sur un repository frontend, grâce à un stub d'indexedDB)

Le plus simple pour review est de lire dans l'ordre les commits je pense

Close #237 
Close #241