### PR TITLE
Réflexion autour des tests de services dans le front

### DIFF
--- a/client/src/domains/__tests__/library-service.test.ts
+++ b/client/src/domains/__tests__/library-service.test.ts
@@ -20,7 +20,9 @@ import {
   MOCK_IMPORTED_STORY,
 } from "./data/imported-story-mocks";
 import { makeSimpleSceneContent } from "@/lib/scene-content";
-import { BuilderStory } from "@/lib/storage/domain";
+import { getTestFactory } from "@/lib/testing/factory";
+
+const factory = getTestFactory();
 
 describe("library-service", () => {
   let libraryService: ReturnType<typeof _getLibraryService>;
@@ -51,33 +53,21 @@ describe("library-service", () => {
 
   describe("getLibrary", () => {
     it("should get all library data, sorted by last played save", async () => {
-      const storyProgressA = {
+      const storyProgressA = factory.storyProgress({
         key: "key-1",
         storyKey: "story-key-1",
-        userKey: undefined,
-        history: [],
-        currentSceneKey: "not-relevant",
         lastPlayedAt: new Date("2025/05/01"),
-      };
-
-      const storyProgressB = {
+      });
+      const storyProgressB = factory.storyProgress({
         key: "key-2",
         storyKey: "story-key-2",
-        userKey: undefined,
-        history: [],
-        currentSceneKey: "not-relevant",
         lastPlayedAt: new Date("2025/06/01"),
-      };
-
-      const storyProgressC = {
+      });
+      const storyProgressC = factory.storyProgress({
         key: "key-3",
         storyKey: "story-key-2",
-        userKey: undefined,
-        history: [],
-        currentSceneKey: "not-relevant",
         lastPlayedAt: new Date("2025/01/01"),
-      };
-
+      });
       localRepository.getUserStoryProgresses = vi.fn(() => {
         return Promise.resolve([
           storyProgressA,
@@ -86,29 +76,15 @@ describe("library-service", () => {
         ]);
       });
 
-      // Story creation dates should be taken into account when getting sorted library data
-      const storyA: BuilderStory = {
+      // Story creation dates shouldn't be taken into account when getting sorted library data
+      const storyA = factory.story.library({
         key: "story-key-1",
-        title: "not-relevant",
-        description: "not-relevant",
-        image: "not-relevant",
-        firstSceneKey: "not-relevant",
-        genres: [],
         creationDate: new Date("2025/10/01"),
-        type: "builder",
-      };
-
-      const storyB: BuilderStory = {
+      });
+      const storyB = factory.story.library({
         key: "story-key-2",
-        title: "not-relevant",
-        description: "not-relevant",
-        image: "not-relevant",
-        firstSceneKey: "not-relevant",
-        genres: [],
         creationDate: new Date("2025/01/01"),
-        type: "builder",
-      };
-
+      });
       localRepository.getStoriesByKeys = vi.fn(() => {
         return Promise.resolve([storyA, storyB]);
       });

--- a/client/src/domains/game/library-service.ts
+++ b/client/src/domains/game/library-service.ts
@@ -45,7 +45,7 @@ export const _getLibraryService = ({
 
   const _getLibrary = async () => {
     const user = await localRepository.getUser();
-    // 1. Retrieving all the storyProgresses of the current user in the database
+    // Retrieving all the storyProgresses of the current user in the database
     const storyProgresses = await localRepository.getUserStoryProgresses(
       user?.key,
     );

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -31,7 +31,7 @@ type Author = {
   username: string;
 };
 
-type StoryBase = {
+export type StoryBase = {
   key: string;
   author?: Author;
   title: string;
@@ -42,14 +42,14 @@ type StoryBase = {
   creationDate: Date;
 };
 
-export type ImportedStory = StoryBase & {
+export type LibraryStory = StoryBase & {
   originalStoryKey?: string;
   type: "imported";
 };
 
 export type BuilderStory = StoryBase & { type: "builder" };
 
-export type Story = ImportedStory | BuilderStory;
+export type Story = LibraryStory | BuilderStory;
 
 export type Action = {
   text: string;

--- a/client/src/lib/testing/factory.ts
+++ b/client/src/lib/testing/factory.ts
@@ -1,10 +1,39 @@
-import { WithoutKey } from "@/types";
-import { Wiki } from "../storage/domain";
+import {
+  BuilderStory,
+  LibraryStory,
+  STORY_GENRES,
+  StoryBase,
+  StoryProgress,
+  Wiki,
+} from "../storage/domain";
 import { faker } from "@faker-js/faker";
+import { nanoid } from "nanoid";
 
-type WikiFactories = { [K in keyof WithoutKey<Wiki>]: () => Wiki[K] };
+type _EntityBase = {
+  key: string;
+  [k: string]: unknown;
+};
 
-const _wikiFactories = {
+type _BaseFactory<T extends _EntityBase> = {
+  [K in keyof T]: () => T[K];
+};
+
+const makeRandomEntity = <T extends _EntityBase>(
+  factory: _BaseFactory<T>,
+  payload: Partial<T>,
+) => {
+  return Object.entries(factory).reduce((acc, [_key, generator]) => {
+    const key = _key as keyof Partial<T>;
+    return {
+      ...acc,
+      [key]: key in payload ? payload[key] : generator(),
+    };
+  }, {} as T);
+};
+
+type WikiFactory = _BaseFactory<Wiki>;
+const _wikiFactory = {
+  key: nanoid,
   author: () => ({
     username: faker.internet.username(),
     key: faker.string.uuid(),
@@ -14,23 +43,59 @@ const _wikiFactories = {
   name: faker.book.title,
   type: () => faker.helpers.arrayElement(["imported", "created"] as const),
   description: faker.word.sample,
-} satisfies WikiFactories;
+} satisfies WikiFactory;
+
+type StoryBaseFactory = _BaseFactory<StoryBase>;
+const _baseStoryFactory = {
+  key: nanoid,
+  creationDate: faker.date.anytime,
+  title: faker.book.title,
+  description: faker.word.sample,
+  firstSceneKey: nanoid,
+  genres: () => faker.helpers.arrayElements(STORY_GENRES, 3),
+  image: faker.image.url,
+} satisfies StoryBaseFactory;
+
+type BuilderStoryFactory = _BaseFactory<BuilderStory>;
+const _builderStoryFactory = {
+  ..._baseStoryFactory,
+  type: () => "builder",
+} satisfies BuilderStoryFactory;
+
+type LibraryStoryFactory = _BaseFactory<LibraryStory>;
+const _libraryStoryFactory = {
+  ..._baseStoryFactory,
+  type: () => "imported",
+} satisfies LibraryStoryFactory;
+
+type StoryProgressFactory = _BaseFactory<StoryProgress>;
+const _storyProgressFactory = {
+  key: nanoid,
+  currentSceneKey: nanoid,
+  history: () => Array.from(Array(5), nanoid),
+  lastPlayedAt: faker.date.anytime,
+  storyKey: nanoid,
+  userKey: nanoid,
+  finished: () => Math.random() > 0.5,
+} satisfies StoryProgressFactory;
 
 export const getTestFactory = () => {
   return {
-    wiki: (partial: Partial<WithoutKey<Wiki>> = {}) => {
-      const wiki = Object.entries(_wikiFactories).reduce(
-        (acc, [_key, generator]) => {
-          const key = _key as keyof Partial<WithoutKey<Wiki>>;
-          return {
-            ...acc,
-            [key]: key in partial ? partial[key] : generator(),
-          };
-        },
-        {} as WithoutKey<Wiki>,
-      );
+    wiki: (partial: Partial<Wiki> = {}) => {
+      return makeRandomEntity(_wikiFactory, partial);
+    },
 
-      return wiki;
+    story: {
+      builder: (partial: Partial<BuilderStory> = {}) => {
+        return makeRandomEntity(_builderStoryFactory, partial);
+      },
+      library: (partial: Partial<LibraryStory> = {}) => {
+        return makeRandomEntity(_libraryStoryFactory, partial);
+      },
+    },
+
+    storyProgress: (partial: Partial<StoryProgress> = {}) => {
+      return makeRandomEntity(_storyProgressFactory, partial);
     },
   };
 };

--- a/client/src/services/common/import-service.ts
+++ b/client/src/services/common/import-service.ts
@@ -1,7 +1,7 @@
 import * as z from "zod/v4";
 import {
   BuilderStory,
-  ImportedStory,
+  LibraryStory,
   Scene,
   Story,
   STORY_GENRES,
@@ -168,7 +168,7 @@ export const _getImportService = ({
     createStory: async ({ story: storyFromImport, type }) => {
       const { key: importedStoryKey, ...importedStory } = storyFromImport.story;
 
-      const storyPayload: WithoutKey<ImportedStory> | WithoutKey<BuilderStory> =
+      const storyPayload: WithoutKey<LibraryStory> | WithoutKey<BuilderStory> =
         {
           ...importedStory,
           type,


### PR DESCRIPTION
Réflexion autour de la manière dont on veut écrire les tests de service 
- On reste sur un pattern ou on mock les repositories
- On facilite la création d'objets dans les tests grâce à une factory
- Update des tests de la library pour prendre en compte le sorting

Close #194 
