### PR TITLE
Wiki - Create category (service + repo)

### DIFF
--- a/client/src/domains/wiki/__tests__/wiki-permission-context.test.ts
+++ b/client/src/domains/wiki/__tests__/wiki-permission-context.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, test, vi } from "vitest";
-import { _getWikiPermissionContext } from "../wiki-permission-context";
+import {
+  _getWikiPermissionContext,
+  WikiPermissionContext,
+} from "../wiki-permission-context";
 import { getStubAuthContext } from "@/domains/user/stubs/stub-auth-context";
 import { getStubWikiRepository } from "../stubs/stub-wiki-repository";
 import { getTestFactory } from "@/lib/testing/factory";
 
 const factory = getTestFactory();
+
+const expectNoPermissions = (context: WikiPermissionContext) => {
+  expect(context.canCreateArticle).toBeFalsy();
+  expect(context.canDeleteArticle).toBeFalsy();
+  expect(context.canEditArticle).toBeFalsy();
+  expect(context.canCreateCategory).toBeFalsy();
+  expect(context.canEditCategory).toBeFalsy();
+  expect(context.canDeleteCategory).toBeFalsy();
+};
+
+const expectPermissions = (context: WikiPermissionContext) => {
+  expect(context.canCreateArticle).toBeTruthy();
+  expect(context.canDeleteArticle).toBeTruthy();
+  expect(context.canEditArticle).toBeTruthy();
+  expect(context.canCreateCategory).toBeTruthy();
+  expect(context.canEditCategory).toBeTruthy();
+  expect(context.canDeleteCategory).toBeTruthy();
+};
 
 describe("wiki permission context", async () => {
   const wikiRepository = getStubWikiRepository();
@@ -20,9 +41,7 @@ describe("wiki permission context", async () => {
   test("no permissions when wiki doesn't exist", async () => {
     wikiRepository.get = vi.fn(() => Promise.resolve(null));
     const context = await _getContext();
-    expect(context.canCreateArticle()).toBeFalsy();
-    expect(context.canDeleteArticle()).toBeFalsy();
-    expect(context.canEditArticle()).toBeFalsy();
+    expectNoPermissions(context);
   });
 
   test("no permissions when user isn't wiki's author", async () => {
@@ -31,26 +50,22 @@ describe("wiki permission context", async () => {
       author: { key: "peter-key", username: "peter-key" },
     });
 
-    wikiRepository.get = vi.fn(() => Promise.resolve({ wiki, sections: [] }));
+    wikiRepository.get = vi.fn(() => Promise.resolve(wiki));
     authContext.getUser = vi.fn(() => Promise.resolve(user));
 
     const context = await _getContext();
-    expect(context.canCreateArticle()).toBeFalsy();
-    expect(context.canDeleteArticle()).toBeFalsy();
-    expect(context.canEditArticle()).toBeFalsy();
+    expectNoPermissions(context);
   });
 
   test("no permissions when user is not logged in & wiki has author", async () => {
     const wiki = factory.wiki({
       author: { key: "bob-key", username: "bob-bidou" },
     });
-    wikiRepository.get = vi.fn(() => Promise.resolve({ wiki, sections: [] }));
+    wikiRepository.get = vi.fn(() => Promise.resolve(wiki));
     authContext.getUser = vi.fn(() => Promise.resolve(null));
 
     const context = await _getContext();
-    expect(context.canCreateArticle()).toBeFalsy();
-    expect(context.canDeleteArticle()).toBeFalsy();
-    expect(context.canEditArticle()).toBeFalsy();
+    expectNoPermissions(context);
   });
 
   test("permissions when user is wiki's author", async () => {
@@ -59,23 +74,19 @@ describe("wiki permission context", async () => {
       author: { key: "bob-key", username: "bob-bidou" },
     });
 
-    wikiRepository.get = vi.fn(() => Promise.resolve({ wiki, sections: [] }));
+    wikiRepository.get = vi.fn(() => Promise.resolve(wiki));
     authContext.getUser = vi.fn(() => Promise.resolve(user));
 
     const context = await _getContext();
-    expect(context.canCreateArticle()).toBeTruthy();
-    expect(context.canDeleteArticle()).toBeTruthy();
-    expect(context.canEditArticle()).toBeTruthy();
+    expectPermissions(context);
   });
 
   test("permissions when user is not logged in and wiki has no author", async () => {
     const wiki = factory.wiki({ author: undefined });
-    wikiRepository.get = vi.fn(() => Promise.resolve({ wiki, sections: [] }));
+    wikiRepository.get = vi.fn(() => Promise.resolve(wiki));
     authContext.getUser = vi.fn(() => Promise.resolve(null));
 
     const context = await _getContext();
-    expect(context.canCreateArticle()).toBeTruthy();
-    expect(context.canDeleteArticle()).toBeTruthy();
-    expect(context.canEditArticle()).toBeTruthy();
+    expectPermissions(context);
   });
 });

--- a/client/src/domains/wiki/errors.ts
+++ b/client/src/domains/wiki/errors.ts
@@ -1,0 +1,5 @@
+export class WikiCategoryNameTaken extends Error {
+  constructor(wikiKey: string, name: string) {
+    super(`Category name [${name}] already taken for wiki ${wikiKey}`);
+  }
+}

--- a/client/src/domains/wiki/stubs/stub-wiki-permission-context.ts
+++ b/client/src/domains/wiki/stubs/stub-wiki-permission-context.ts
@@ -1,18 +1,13 @@
-import { vi } from "vitest";
 import { WikiPermissionContext } from "../wiki-permission-context";
-import { MockPort } from "@/types";
-
-type StubWikiPermissionContext = MockPort<WikiPermissionContext>;
 
 export const getStubWikiPermissionContextFactory =
-  ({
-    canCreateArticle,
-    canDeleteArticle,
-    canEditArticle,
-  }: Partial<Record<keyof WikiPermissionContext, boolean>> = {}) =>
-  async (): Promise<StubWikiPermissionContext> =>
+  (mockedCtx: Partial<WikiPermissionContext> = {}) =>
+  async (): Promise<WikiPermissionContext> =>
     Promise.resolve({
-      canCreateArticle: vi.fn(() => canCreateArticle ?? true),
-      canDeleteArticle: vi.fn(() => canDeleteArticle ?? true),
-      canEditArticle: vi.fn(() => canEditArticle ?? true),
+      canCreateArticle: mockedCtx.canCreateArticle ?? true,
+      canDeleteArticle: mockedCtx.canDeleteArticle ?? true,
+      canEditArticle: mockedCtx.canEditArticle ?? true,
+      canCreateCategory: mockedCtx.canCreateCategory ?? true,
+      canEditCategory: mockedCtx.canEditCategory ?? true,
+      canDeleteCategory: mockedCtx.canDeleteCategory ?? true,
     });

--- a/client/src/domains/wiki/stubs/stub-wiki-repository.ts
+++ b/client/src/domains/wiki/stubs/stub-wiki-repository.ts
@@ -10,18 +10,17 @@ export const getStubWikiRepository = (): WikiRepositoryPort => ({
   getUserWikis: vi.fn(async () => Promise.resolve([])),
   bulkUpdate: vi.fn(async () => Promise.resolve()),
   create: vi.fn(async () => Promise.resolve(nanoid())),
-  get: vi.fn(async () =>
-    Promise.resolve({
-      wiki: factory.wiki(),
-      sections: [
-        {
-          category: factory.wikiCategory(),
-          articles: [{ title: faker.book.title(), key: nanoid() }],
-        },
-      ],
-    }),
+  get: vi.fn(async () => Promise.resolve(factory.wiki())),
+  getSections: vi.fn(async () =>
+    Promise.resolve([
+      {
+        category: factory.wikiCategory(),
+        articles: [{ title: faker.book.title(), key: nanoid() }],
+      },
+    ]),
   ),
   createArticle: vi.fn(async () => Promise.resolve(nanoid())),
   updateArticle: vi.fn(async () => Promise.resolve()),
   getArticle: vi.fn(async () => Promise.resolve(factory.wikiArticle())),
+  createCategory: vi.fn(async () => Promise.resolve(nanoid())),
 });

--- a/client/src/domains/wiki/types.ts
+++ b/client/src/domains/wiki/types.ts
@@ -1,7 +1,9 @@
 import { Wiki, WikiCategory } from "@/lib/storage/domain";
 
+export type WikiDataCategory = Omit<WikiCategory, "wikiKey">;
+
 export type WikiSection = {
-  category: WikiCategory | null;
+  category: WikiDataCategory | null;
   articles: { key: string; title: string }[];
 };
 

--- a/client/src/domains/wiki/wiki-permission-context.ts
+++ b/client/src/domains/wiki/wiki-permission-context.ts
@@ -2,9 +2,12 @@ import { AuthContextPort, getAuthContext } from "../user/auth-context";
 import { getDexieWikiRepository, WikiRepositoryPort } from "./wiki-repository";
 
 export type WikiPermissionContext = {
-  canCreateArticle: () => boolean;
-  canEditArticle: () => boolean;
-  canDeleteArticle: () => boolean;
+  canCreateArticle: boolean;
+  canEditArticle: boolean;
+  canDeleteArticle: boolean;
+  canCreateCategory: boolean;
+  canEditCategory: boolean;
+  canDeleteCategory: boolean;
 };
 
 export const _getWikiPermissionContext = async ({
@@ -17,12 +20,15 @@ export const _getWikiPermissionContext = async ({
   wikiRepository: WikiRepositoryPort;
 }): Promise<WikiPermissionContext> => {
   const user = await authContext.getUser();
-  const wikiAuthor = (await wikiRepository.get(wikiKey))?.wiki.author;
+  const wikiAuthor = (await wikiRepository.get(wikiKey))?.author;
 
   return {
-    canCreateArticle: () => wikiAuthor?.key === user?.key,
-    canEditArticle: () => wikiAuthor?.key === user?.key,
-    canDeleteArticle: () => wikiAuthor?.key === user?.key,
+    canCreateArticle: wikiAuthor?.key === user?.key,
+    canEditArticle: wikiAuthor?.key === user?.key,
+    canDeleteArticle: wikiAuthor?.key === user?.key,
+    canCreateCategory: wikiAuthor?.key === user?.key,
+    canEditCategory: wikiAuthor?.key === user?.key,
+    canDeleteCategory: wikiAuthor?.key === user?.key,
   };
 };
 

--- a/client/src/lib/storage/dexie/dexie-db.ts
+++ b/client/src/lib/storage/dexie/dexie-db.ts
@@ -26,7 +26,7 @@ export type DexieDatabase = Dexie & Tables;
 export const db = new Dexie("story-builder") as DexieDatabase;
 
 const tables: Record<keyof Tables, string> = {
-  user: "&key, username, email",
+  user: "&key, &username, email",
   stories:
     "&key, firstSceneKey, title, description, image, status, genres, publicationDate, creationDate, author, finished",
   scenes: "&key, storyKey, title, content, actions, builderParams",
@@ -39,7 +39,7 @@ const tables: Record<keyof Tables, string> = {
 export const TABLE_NAMES = Object.keys(tables);
 
 export const createDb = (db: DexieDatabase) => {
-  db.version(2).stores(tables);
+  db.version(3).stores(tables);
 
   db.on("populate", async () => {
     // Add story to builder

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -99,8 +99,10 @@ export type WikiArticle = {
 };
 
 export type WikiCategory = {
+  wikiKey: string;
   key: string;
   name: string;
+  color: string;
 };
 
 export const ENTITIES = [

--- a/client/src/lib/testing/factory.ts
+++ b/client/src/lib/testing/factory.ts
@@ -64,8 +64,10 @@ const _wikiArticleFactory = {
 type WikiCategoryFactory = _BaseFactory<WikiCategory>;
 const _wikiCategoryFactory = {
   key: nanoid,
+  wikiKey: nanoid,
   name: () =>
     faker.helpers.arrayElement(["culture", "people", "event", "geography"]),
+  color: faker.color.rgb,
 } satisfies WikiCategoryFactory;
 
 type StoryBaseFactory = _BaseFactory<StoryBase>;

--- a/client/src/routes/wikis/$wikiKey/$articleKey/edit.tsx
+++ b/client/src/routes/wikis/$wikiKey/$articleKey/edit.tsx
@@ -25,7 +25,7 @@ function RouteComponent() {
 
   if (!articleData || !wikiData || !permissions) return <ErrorMessage />;
 
-  if (!permissions.canEditArticle()) {
+  if (!permissions.canEditArticle) {
     return (
       <ErrorMessage className="flex flex-col gap-2">
         You don't have permission to create article in this wiki...

--- a/client/src/routes/wikis/$wikiKey/new.tsx
+++ b/client/src/routes/wikis/$wikiKey/new.tsx
@@ -16,7 +16,7 @@ const RouteComponent = () => {
 
   if (!wikiData || !permissions) return <ErrorMessage />;
 
-  if (!permissions.canCreateArticle()) {
+  if (!permissions.canCreateArticle) {
     return (
       <ErrorMessage className="flex flex-col gap-2">
         You don't have permission to create article in this wiki...

--- a/client/src/wikis/article-editor.tsx
+++ b/client/src/wikis/article-editor.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { ArticleSchema, articleSchema } from "./schema";
 import { useArticleActions } from "./hooks/use-article-actions";
 import {
   Button,
@@ -16,6 +15,7 @@ import { CornerDownLeft } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useWikiStore } from "./hooks/use-wiki-store";
 import { RichText } from "@/design-system/components/editor/blocks/rich-text-editor";
+import { ArticleSchema, articleSchema } from "./schemas";
 
 type UpdateProps =
   | {

--- a/client/src/wikis/article-empty-state.tsx
+++ b/client/src/wikis/article-empty-state.tsx
@@ -26,7 +26,7 @@ export const ArticleEmptyState = () => {
             ? "This wiki is empty..."
             : "Select an article in the bar on the left"}
         </p>
-        {permissions.canCreateArticle() && (
+        {permissions.canCreateArticle && (
           <Link
             to="/wikis/$wikiKey/new"
             params={{ wikiKey: wikiData.wiki.key }}

--- a/client/src/wikis/article.tsx
+++ b/client/src/wikis/article.tsx
@@ -1,19 +1,20 @@
 import { Title } from "@/design-system/components";
 import { Button } from "@/design-system/primitives";
 import { Badge } from "@/design-system/primitives/badge";
-import { WikiArticle, WikiCategory } from "@/lib/storage/domain";
+import { WikiArticle } from "@/lib/storage/domain";
 import { Link } from "@tanstack/react-router";
 import { SerializedEditorState } from "lexical";
 import { PencilIcon } from "lucide-react";
 import { useWikiStore } from "./hooks/use-wiki-store";
 import { RichText } from "@/design-system/components/editor/blocks/rich-text-editor";
+import { WikiDataCategory } from "@/domains/wiki/types";
 
 export const Article = ({
   article,
   category,
 }: {
   article: WikiArticle;
-  category: WikiCategory | null;
+  category: WikiDataCategory | null;
 }) => {
   const { canEditArticle: canEdit } = useWikiStore(
     (state) => state.permissions,
@@ -25,7 +26,7 @@ export const Article = ({
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Title variant="article">{article.title}</Title>
-            {canEdit() && (
+            {canEdit && (
               <Link
                 to="/wikis/$wikiKey/$articleKey/edit"
                 params={{ articleKey: article.key, wikiKey: article.wikiKey }}

--- a/client/src/wikis/hooks/use-article-actions.ts
+++ b/client/src/wikis/hooks/use-article-actions.ts
@@ -1,8 +1,8 @@
 import { getWikiService } from "@/domains/wiki/wiki-service";
-import { ArticleSchema } from "../schema";
 import { useWikiStore } from "./use-wiki-store";
 import { toast } from "sonner";
 import { useNavigate } from "@tanstack/react-router";
+import { ArticleSchema } from "../schemas";
 
 export const useArticleActions = () => {
   const svc = getWikiService();

--- a/client/src/wikis/schemas.ts
+++ b/client/src/wikis/schemas.ts
@@ -11,3 +11,12 @@ export const articleSchema = z.object({
 });
 
 export type ArticleSchema = z.infer<typeof articleSchema>;
+
+export const categorySchema = z.object({
+  name: z
+    .string()
+    .max(250, { error: "Name has to be less than 250 characters" }),
+  color: z.string(), // TODO: use HEX_COLOR_REGEX from https://github.com/JeremieLeymarie/story-builder/pull/287
+});
+
+export type CategorySchema = z.infer<typeof categorySchema>;


### PR DESCRIPTION
Close #285 

Partie logique métier de la création de catégorie
+ petite refacto pour séparer la récupération des données du wiki + des sections (catégories + noms d'article)