### PR TITLE
Fix scene editor defocus bug

### DIFF
--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
@@ -66,10 +66,11 @@ export const SceneContentForm = ({
                   entityKey={scenePayload.key}
                 >
                   <RichText
+                    key={scenePayload.key}
                     onSerializedChange={field.onChange}
                     initialState={scenePayload.content}
                     editable
-                    className="h-[300px] max-w-[450px]"
+                    className="h-75 max-w-112.5"
                     toolbarPlugins={[
                       <WikiPlugin wikiKey={story.wikiKey ?? null} />,
                     ]}

--- a/client/src/design-system/components/editor/components/rich-text-editor.tsx
+++ b/client/src/design-system/components/editor/components/rich-text-editor.tsx
@@ -38,8 +38,6 @@ export const RichText = ({
   editorNodes?: EditorNode[];
   textDisplayMode: TextDisplayMode;
 }) => {
-  // This allows lexical to refresh it's initial state when the content changes from the outside
-  const state = JSON.stringify(initialState);
   return (
     <div
       className={cn(
@@ -49,11 +47,10 @@ export const RichText = ({
       )}
     >
       <LexicalComposer
-        key={state}
         initialConfig={{
           ...BASE_EDITOR_CONFIG,
           nodes: [...(BASE_EDITOR_CONFIG.nodes ?? []), ...(editorNodes ?? [])],
-          editorState: state,
+          editorState: JSON.stringify(initialState),
           editable,
         }}
       >


### PR DESCRIPTION
bliblablou le state change donc on unmount/remount tout le rich text donc il perd le focus. Donc je monte la key d'un cran dans l'arbre et j'utilise la key de la scène plutôt 

Close #391