### PR TITLE
Builder - Fix scene editor

### DIFF
--- a/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
@@ -2,21 +2,13 @@ import { Button, Form, FormDescription } from "@/design-system/primitives";
 import { PlusIcon } from "lucide-react";
 import { ActionItem } from "./action-item";
 import { useEditActionsForm } from "@/builder/hooks/use-edit-actions-form";
-import { Action } from "@/lib/storage/domain";
-import { useBuilderActions } from "@/builder/hooks/use-builder-actions";
 
 export const ActionsForm = ({
-  sceneKey,
-  actions,
+  actionFormProps,
 }: {
-  sceneKey: string;
-  actions: Action[];
+  actionFormProps: ReturnType<typeof useEditActionsForm>;
 }) => {
-  const { updateScene } = useBuilderActions();
-  const { form, append, fields, remove } = useEditActionsForm({
-    actions,
-    onSave: (payload) => updateScene({ key: sceneKey, ...payload }),
-  });
+  const { append, fields, form, remove } = actionFormProps;
 
   return (
     <Form {...form}>

--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
@@ -7,27 +7,27 @@ import {
   FormMessage,
   Input,
 } from "@/design-system/primitives";
-import { SceneUpdatePayload } from "./schema";
 import { SetFirstSceneSwitch } from "./set-first-scene-switch";
 import { RichText } from "@/design-system/components/editor/components/rich-text-editor";
 import { useBuilderContext } from "@/builder/hooks/use-builder-context";
 import { EditorContextProvider } from "@/design-system/components/editor/hooks/use-editor-context";
 import { WikiPlugin } from "../../wiki-lexical-plugin/wiki-lexical-plugin";
 import { WikiNode } from "@/builder/lexical-wiki-node";
-import { useEditSceneContentForm } from "@/builder/hooks/use-edit-scene-content-form";
 import { useBuilderActions } from "@/builder/hooks/use-builder-actions";
+import { SceneContentFormType } from "@/builder/hooks/use-edit-scene-content-form";
+import { LexicalContent } from "@/lib/lexical-content";
 
 export const SceneContentForm = ({
-  scenePayload,
+  form,
+  sceneKey,
+  content,
 }: {
-  scenePayload: SceneUpdatePayload;
+  form: SceneContentFormType;
+  sceneKey: string;
+  content: LexicalContent;
 }) => {
-  const { updateScene, setFirstScene } = useBuilderActions();
+  const { setFirstScene } = useBuilderActions();
   const { story } = useBuilderContext();
-  const form = useEditSceneContentForm({
-    defaultValues: { title: scenePayload.title, content: scenePayload.content },
-    onSave: (payload) => updateScene({ key: scenePayload.key, ...payload }),
-  });
 
   return (
     <Form {...form}>
@@ -38,8 +38,8 @@ export const SceneContentForm = ({
         }}
       >
         <SetFirstSceneSwitch
-          setFirstScene={() => setFirstScene(scenePayload.key)}
-          sceneKey={scenePayload.key}
+          setFirstScene={() => setFirstScene(sceneKey)}
+          sceneKey={sceneKey}
         />
         <FormField
           control={form.control}
@@ -61,14 +61,11 @@ export const SceneContentForm = ({
             <FormItem>
               <FormLabel>Content</FormLabel>
               <FormControl>
-                <EditorContextProvider
-                  entityType="scene"
-                  entityKey={scenePayload.key}
-                >
+                <EditorContextProvider entityType="scene" entityKey={sceneKey}>
                   <RichText
-                    key={scenePayload.key}
+                    key={sceneKey}
                     onSerializedChange={field.onChange}
-                    initialState={scenePayload.content}
+                    initialState={content}
                     editable
                     className="h-75 max-w-112.5"
                     toolbarPlugins={[

--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-editor.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-editor.tsx
@@ -11,6 +11,9 @@ import {
   ToolbarHeader,
   ToolbarTitle,
 } from "@/design-system/components/toolbar";
+import { useEditSceneContentForm } from "@/builder/hooks/use-edit-scene-content-form";
+import { useBuilderActions } from "@/builder/hooks/use-builder-actions";
+import { useEditActionsForm } from "@/builder/hooks/use-edit-actions-form";
 
 export const SceneEditorHeader = () => {
   return (
@@ -21,6 +24,19 @@ export const SceneEditorHeader = () => {
 };
 
 export const SceneEditor = ({ scene }: { scene: SceneUpdatePayload }) => {
+  // Both forms have to be declared here instead of in each form component because tabs are unmounted
+  // when inactive, which causes data freshness issues when switching tabs
+  // This is the simplest workaround
+  const { updateScene } = useBuilderActions();
+  const contentForm = useEditSceneContentForm({
+    values: { title: scene.title, content: scene.content },
+    onSave: (payload) => updateScene({ key: scene.key, ...payload }),
+  });
+  const actionFormProps = useEditActionsForm({
+    actions: scene.actions,
+    onSave: (payload) => updateScene({ key: scene.key, ...payload }),
+  });
+
   return (
     <Tabs defaultValue="scene" className="w-full">
       <TabsList>
@@ -29,10 +45,14 @@ export const SceneEditor = ({ scene }: { scene: SceneUpdatePayload }) => {
       </TabsList>
 
       <TabsContent value="scene">
-        <SceneContentForm scenePayload={scene} />
+        <SceneContentForm
+          form={contentForm}
+          sceneKey={scene.key}
+          content={scene.content}
+        />
       </TabsContent>
       <TabsContent value="actions">
-        <ActionsForm sceneKey={scene.key} actions={scene.actions} />
+        <ActionsForm actionFormProps={actionFormProps} />
       </TabsContent>
     </Tabs>
   );

--- a/client/src/builder/hooks/use-builder-actions.ts
+++ b/client/src/builder/hooks/use-builder-actions.ts
@@ -4,15 +4,11 @@ import { useBuilderContext } from "./use-builder-context";
 import { useBuilderError } from "./use-builder-error";
 import { Scene } from "@/lib/storage/domain";
 import { sceneToNodeAdapter } from "../adapters";
-import { useBuilderEditorStore } from "./use-builder-editor-store";
 
 export const useBuilderActions = () => {
   const { story, setStory, builderService } = useBuilderContext();
   const { setNodes } = useReactFlow<BuilderNode>();
   const { handleError } = useBuilderError();
-  const updateSceneEditor = useBuilderEditorStore(
-    (state) => state.updatePayload,
-  );
 
   const updateScene = async (scene: Partial<Scene> & Pick<Scene, "key">) => {
     try {
@@ -25,13 +21,6 @@ export const useBuilderActions = () => {
             : n,
         ),
       );
-      updateSceneEditor({
-        type: "scene-editor",
-        payload: {
-          scene: updated,
-          isFirstScene: story.firstSceneKey === updated.key,
-        },
-      });
     } catch (err) {
       handleError(err);
     }

--- a/client/src/builder/hooks/use-builder-editor-store.ts
+++ b/client/src/builder/hooks/use-builder-editor-store.ts
@@ -19,7 +19,6 @@ type Editors = SceneEditorStore | StoryEditorStore | null;
 type BuilderStore = {
   open: (editor: Exclude<Editors, null>) => void;
   close: () => void;
-  updatePayload: (editor: Exclude<Editors, null>) => void;
   editor: Editors;
 };
 
@@ -29,20 +28,13 @@ export const EMPTY_BUILDER_EDITOR_STATE: EditorBase<null, null> = {
 };
 
 export const useBuilderEditorStore = createWithEqualityFn<BuilderStore>(
-  (set, get) => ({
+  (set) => ({
     editor: null,
     open(editor) {
       set({ editor });
     },
     close() {
       set({ editor: null });
-    },
-    updatePayload(editor) {
-      if (editor.type !== get().editor?.type)
-        throw new Error(
-          `Cannot update ${editor.type}'s type: this editor is not open.`,
-        );
-      set({ editor });
     },
   }),
   shallow,

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -80,7 +80,7 @@ export const useEditActionsForm = ({
 }) => {
   const form = useForm<EditActionsSchema>({
     resolver: zodResolver(schema),
-    defaultValues: {
+    values: {
       actions: actions.map(adaptDomainAction),
     },
   });

--- a/client/src/builder/hooks/use-edit-scene-content-form.ts
+++ b/client/src/builder/hooks/use-edit-scene-content-form.ts
@@ -17,26 +17,27 @@ export type SceneSchema = z.infer<typeof sceneSchema>;
 export type SceneUpdatePayload = Omit<Scene, "builderParams" | "actions">;
 
 export const useEditSceneContentForm = ({
-  defaultValues,
+  values,
   onSave,
 }: {
-  defaultValues: Partial<SceneSchema>;
+  values: SceneSchema;
   onSave: (payload: SceneSchema) => void;
 }) => {
   const form = useForm<SceneSchema>({
     resolver: zodResolver(sceneSchema),
-    defaultValues,
+    values,
   });
 
   useAutoSubmitForm({
     form,
-    onSubmit: (values) => {
-      return onSave({
+    onSubmit: (values) =>
+      onSave({
         content: values.content,
         title: values.title,
-      });
-    },
+      }),
   });
 
   return form;
 };
+
+export type SceneContentFormType = ReturnType<typeof useEditSceneContentForm>;


### PR DESCRIPTION
En gros le pb était que les tabs inactives sont unmount quand elles sont pas affichées, donc le form perdait les valeurs précédentes, et au retour sur le tab on récupèrait les valeurs du moment de l'ouverture de l'éditeur

Donc j'ai remonté le state des forms au dessus des tabs pour qu'ils ne soient pas unmount quand on change de tab. Ça améliore aussi les perfs puisqu'on a un render de moins. 

Close #395 