### PR TITLE
Fix probabilities on edges

### DIFF
--- a/client/src/builder/adapters/index.ts
+++ b/client/src/builder/adapters/index.ts
@@ -1,4 +1,4 @@
-import { Scene, Story } from "@/lib/storage/domain";
+import { Action, Scene, Story } from "@/lib/storage/domain";
 import { BuilderEdge, SceneProps } from "../types";
 import { Node } from "@xyflow/react";
 
@@ -35,29 +35,30 @@ const hashEdgeId = ({
   return `${sceneKey}${EDGE_ID_SEPARATOR}${actionKey}${EDGE_ID_SEPARATOR}${targetSceneKey}`;
 };
 
+export const actionToEdgesAdapter = (action: Action, sceneKey: string) =>
+  action.targets.map(
+    (target) =>
+      ({
+        type: "edge",
+        sourceHandle: action.key,
+        source: sceneKey,
+        target: target.sceneKey,
+        targetHandle: null,
+        id: hashEdgeId({
+          sceneKey: sceneKey,
+          actionKey: action.key,
+          targetSceneKey: target.sceneKey,
+        }),
+        data: {
+          probability: target.probability,
+          hasSiblings: action.targets.length > 1,
+        },
+      }) satisfies BuilderEdge,
+  );
+
 const sceneToEdgesAdapter = (scene: Scene): BuilderEdge[] => {
   const edges = scene.actions
-    .flatMap((action) => {
-      return action.targets.map(
-        (target) =>
-          ({
-            type: "edge",
-            sourceHandle: action.key,
-            source: scene.key,
-            target: target.sceneKey,
-            targetHandle: null,
-            id: hashEdgeId({
-              sceneKey: scene.key,
-              actionKey: action.key,
-              targetSceneKey: target.sceneKey,
-            }),
-            data: {
-              probability: target.probability,
-              hasSiblings: action.targets.length > 1,
-            },
-          }) satisfies BuilderEdge,
-      );
-    })
+    .flatMap((action) => actionToEdgesAdapter(action, scene.key))
     .filter((action) => !!action.target);
 
   return edges;

--- a/client/src/builder/hooks/use-builder-edges.tsx
+++ b/client/src/builder/hooks/use-builder-edges.tsx
@@ -1,17 +1,10 @@
-import {
-  Connection,
-  FinalConnectionState,
-  useReactFlow,
-  addEdge,
-} from "@xyflow/react";
+import { Connection, FinalConnectionState, useReactFlow } from "@xyflow/react";
 import { BuilderEdge, BuilderNode } from "../types";
 import { useErrorToast } from "./use-error-toast";
 import { DEFAULT_SCENE, useAddScene } from "./use-add-scene";
 import { useBuilderContext } from "./use-builder-context";
 import { Scene } from "@/lib/storage/domain";
-
-const edgeHasSiblings = (action: Scene["actions"][number]) =>
-  action.targets.length > 1;
+import { actionToEdgesAdapter } from "../adapters";
 
 const isEdgeFromAction = (edge: BuilderEdge, actionKey: string) =>
   edge.sourceHandle === actionKey;
@@ -23,6 +16,20 @@ export const useBuilderEdges = () => {
   const { addScene } = useAddScene();
   const { screenToFlowPosition } = useReactFlow();
   const { builderService } = useBuilderContext();
+
+  const _updateEdges = (updatedScene: Scene, sourceActionKey: string) => {
+    const sourceAction = updatedScene.actions.find(
+      (a) => a.key === sourceActionKey,
+    );
+    if (!sourceAction) throw new Error(`Action not found`);
+
+    const edges = actionToEdgesAdapter(sourceAction, updatedScene.key);
+    // 1. Filter out existing edges from action
+    // 2. Re-add all updated edges
+    setEdges((prev) =>
+      prev.filter((e) => !isEdgeFromAction(e, sourceActionKey)).concat(edges),
+    );
+  };
 
   const onConnect = async (connection: Connection) => {
     const sourceSceneKey = connection.source;
@@ -39,32 +46,7 @@ export const useBuilderEdges = () => {
         destinationSceneKey: targetSceneKey,
         actionKey: sourceActionKey,
       });
-      const action = scene.actions.find((a) => a.key === sourceActionKey);
-      if (!action) throw new Error("New action should be created");
-
-      // Update React Flow
-      setEdges((prev) => {
-        // Set `hasSiblings: true` for other edges coming from the same action
-        const updatedEdges = prev.map((e) =>
-          isEdgeFromAction(e, sourceActionKey)
-            ? { ...e, data: { ...e.data!, hasSiblings: true } }
-            : e,
-        );
-        // Add new edge
-        return addEdge<BuilderEdge>(
-          {
-            ...connection,
-            type: "edge",
-            data: {
-              probability:
-                action.targets.find((t) => t.sceneKey === targetSceneKey)
-                  ?.probability ?? 100, // TODO: handle error?
-              hasSiblings: action.targets.length > 1,
-            },
-          },
-          updatedEdges,
-        );
-      });
+      _updateEdges(scene, sourceActionKey);
     } catch (e) {
       handleError(e);
     }
@@ -138,27 +120,7 @@ export const useBuilderEdges = () => {
           actionKey: sourceActionKey,
           targetSceneKey: targetSceneKey,
         })
-        .then((scene) => {
-          const sourceAction = scene.actions.find(
-            (a) => a.key === sourceActionKey,
-          );
-          if (!sourceAction)
-            throw new Error(`Action not found for edge ${edge.id}`);
-
-          setEdges((prev) =>
-            prev.map((e) =>
-              isEdgeFromAction(e, sourceActionKey)
-                ? {
-                    ...e,
-                    data: {
-                      ...e.data!,
-                      hasSiblings: edgeHasSiblings(sourceAction),
-                    },
-                  }
-                : e,
-            ),
-          );
-        })
+        .then((scene) => _updateEdges(scene, sourceActionKey))
         .catch(handleError);
     });
   };

--- a/client/src/domains/builder/__tests__/builder-service.test.ts
+++ b/client/src/domains/builder/__tests__/builder-service.test.ts
@@ -84,37 +84,6 @@ describe("builder-service", () => {
   });
 
   describe("addSceneConnection", () => {
-    test("should add connection between scenes", async () => {
-      sceneRepository.get.mockResolvedValue(BASIC_SCENE);
-
-      await builderService.addSceneConnection({
-        sourceSceneKey: BASIC_SCENE.key,
-        destinationSceneKey: "dest",
-        actionKey: "action-a",
-      });
-
-      expect(localRepository.updatePartialScene).toHaveBeenCalledWith(
-        BASIC_SCENE.key,
-        {
-          actions: [
-            {
-              key: "action-a",
-              type: "simple",
-              text: "action A",
-              targets: [{ sceneKey: "dest", probability: 0 }],
-            },
-            {
-              key: "action-b",
-
-              type: "simple",
-              text: "action B",
-              targets: [],
-            },
-          ],
-        },
-      );
-    });
-
     test("should do nothing when given invalid action key", async () => {
       sceneRepository.get.mockResolvedValue(BASIC_SCENE);
 
@@ -174,7 +143,38 @@ describe("builder-service", () => {
       );
     });
 
-    test("should set probability to 0 when adding edge", async () => {
+    test("should add connection between scenes", async () => {
+      sceneRepository.get.mockResolvedValue(BASIC_SCENE);
+
+      await builderService.addSceneConnection({
+        sourceSceneKey: BASIC_SCENE.key,
+        destinationSceneKey: "dest",
+        actionKey: "action-a",
+      });
+
+      expect(localRepository.updatePartialScene).toHaveBeenCalledWith(
+        BASIC_SCENE.key,
+        {
+          actions: [
+            {
+              key: "action-a",
+              type: "simple",
+              text: "action A",
+              targets: [{ sceneKey: "dest", probability: 100 }],
+            },
+            {
+              key: "action-b",
+
+              type: "simple",
+              text: "action B",
+              targets: [],
+            },
+          ],
+        },
+      );
+    });
+
+    test("should set probability to 0 when adding another edge", async () => {
       sceneRepository.get.mockResolvedValue(
         factory.scene({
           key: "scene-a",

--- a/client/src/domains/builder/builder-service.ts
+++ b/client/src/domains/builder/builder-service.ts
@@ -92,7 +92,10 @@ export const _getBuilderService = ({
             ...action,
             targets: [
               ...action.targets,
-              { sceneKey: destinationSceneKey, probability: 0 },
+              {
+                sceneKey: destinationSceneKey,
+                probability: action.targets.length > 0 ? 0 : 100,
+              },
             ],
           } satisfies Action;
         }


### PR DESCRIPTION
Deux bugs pour le prix d'un : 
- 1er commit : dans le domaine, je mettais toujours 0 en probabilité à la création, alors que le premier edge créé doit toujours avoir 100%
- 2eme commit : dans use-builder-edges, je faisais un peu de logique compliquée pour update le flow après les actions domaine d'ajout/suppression, ce qui causait des pbs d'update. j'ai simplifié en utlisant les adapters du builder pour set les edges du flow

Close #419