### PR TITLE
Small UI improvements

### DIFF
--- a/client/src/builder/adapters/index.ts
+++ b/client/src/builder/adapters/index.ts
@@ -27,7 +27,7 @@ type EdgeIdentifier = {
 
 const EDGE_ID_SEPARATOR = "#";
 
-const hashEdgeId = ({
+export const hashEdgeId = ({
   sceneKey,
   actionKey,
   targetSceneKey,

--- a/client/src/home/builder-showcase.tsx
+++ b/client/src/home/builder-showcase.tsx
@@ -15,6 +15,7 @@ import { BuilderContextProvider } from "@/builder/hooks/use-builder-context";
 import { Story } from "@/lib/storage/domain";
 import { makeSimpleLexicalContent } from "@/lib/lexical-content";
 import { getStubBuilderService } from "@/domains/builder/stubs/stub-builder-service";
+import { hashEdgeId } from "@/builder/adapters";
 
 const nodeTypes = { scene: SceneNode };
 
@@ -29,13 +30,13 @@ const NODES: BuilderNode[] = [
         {
           key: "action-a",
           type: "simple",
-          targets: [],
+          targets: [{ sceneKey: "forest-fake-scene-key", probability: 100 }],
           text: "Go to the forest",
         },
         {
           key: "action-b",
           type: "simple",
-          targets: [],
+          targets: [{ sceneKey: "village-fake-scene-key", probability: 100 }],
           text: "Go to the village",
         },
       ],
@@ -45,7 +46,7 @@ const NODES: BuilderNode[] = [
       isEditable: false,
       builderParams: { position: { x: 50, y: 150 } },
     },
-    id: "scene-1",
+    id: "first-fake-scene-key",
     position: { x: 50, y: 150 },
     type: "scene",
   },
@@ -62,7 +63,7 @@ const NODES: BuilderNode[] = [
       isEditable: false,
       builderParams: { position: { x: 550, y: 50 } },
     },
-    id: "scene-2",
+    id: "forest-fake-scene-key",
     position: { x: 550, y: 50 },
     type: "scene",
   },
@@ -79,7 +80,7 @@ const NODES: BuilderNode[] = [
       isEditable: false,
       builderParams: { position: { x: 550, y: 350 } },
     },
-    id: "scene-3",
+    id: "village-fake-scene-key",
     position: { x: 550, y: 350 },
     type: "scene",
   },
@@ -87,16 +88,24 @@ const NODES: BuilderNode[] = [
 
 const EDGES: BuilderEdge[] = [
   {
-    id: "edge-1",
-    source: "scene-1",
-    target: "scene-2",
-    sourceHandle: "first-fake-scene-key-0",
+    id: hashEdgeId({
+      actionKey: "action-a",
+      sceneKey: "first-fake-scene-key",
+      targetSceneKey: "forest-fake-scene-key",
+    }),
+    source: "first-fake-scene-key",
+    target: "forest-fake-scene-key",
+    sourceHandle: "action-a",
   },
   {
-    id: "edge-2",
-    source: "scene-1",
-    target: "scene-3",
-    sourceHandle: "first-fake-scene-key-1",
+    id: hashEdgeId({
+      actionKey: "action-b",
+      sceneKey: "first-fake-scene-key",
+      targetSceneKey: "village-fake-scene-key",
+    }),
+    source: "first-fake-scene-key",
+    target: "village-fake-scene-key",
+    sourceHandle: "action-b",
   },
 ];
 
@@ -116,7 +125,7 @@ export const BuilderShowcase = () => {
   const [edges, , onEdgesChange] = useEdgesState(EDGES);
 
   return (
-    <div className="bg-primary flex h-[400px] w-full max-lg:h-fit max-lg:flex-col">
+    <div className="bg-primary flex h-100 w-full max-lg:h-fit max-lg:flex-col">
       <div className="flex h-full w-5/12 items-center max-lg:w-full max-lg:py-8">
         <div className="flex w-full flex-col px-12">
           <Title variant="primary">Create your own stories!</Title>
@@ -137,7 +146,7 @@ export const BuilderShowcase = () => {
           </div>
         </div>
       </div>
-      <div className="h-full w-7/12 bg-white max-lg:h-[400px] max-lg:w-full">
+      <div className="h-full w-7/12 bg-white max-lg:h-100 max-lg:w-full">
         <BuilderContextProvider
           refresh={async () => {}}
           story={MOCK_STORY}

--- a/client/src/home/last-game-section.tsx
+++ b/client/src/home/last-game-section.tsx
@@ -16,9 +16,9 @@ export const LastGameSection = ({ lastGame }: { lastGame: Story }) => {
       }}
     >
       <div className="flex flex-wrap items-center gap-32 max-lg:justify-center max-lg:gap-12">
-        <div className="space-y-4">
+        <div className="w-full space-y-4">
           <Title variant="section">Pick up where you left off:</Title>
-          <Title>{lastGame.title}</Title>
+          <Title className="max-w-fit">{lastGame.title}</Title>
           {lastGame.genres.length && (
             <div className="flex flex-wrap gap-2">
               {lastGame.genres.map((genre) => (

--- a/client/src/library/game-detail.tsx
+++ b/client/src/library/game-detail.tsx
@@ -3,10 +3,15 @@ import { Story } from "@/lib/storage/domain";
 import { ExtendedProgress } from "./types";
 import { useRouter } from "@tanstack/react-router";
 import { getLibraryService } from "@/domains/game/library-service";
-import { Play, Trash2 } from "lucide-react";
+import { InfoIcon, Play, Trash2 } from "lucide-react";
 import { StoryGenreBadge } from "@/design-system/components";
 import { Button } from "@/design-system/primitives/button";
 import { Progress } from "@/design-system/primitives/progress";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/design-system/primitives/tooltip";
 
 type Props = {
   story: Story;
@@ -55,16 +60,12 @@ export const LibraryGameDetail = ({
   return (
     <div className="bg-background min-h-screen">
       <div className="mx-auto max-w-6xl px-6 py-8">
-        <div className="mb-12 flex gap-8">
+        <div className="mb-12 flex flex-col gap-8 md:flex-row">
           <div className="shrink-0">
             <img
               src={story.image}
               alt={story.title}
-              style={{
-                width: "calc(var(--spacing) * 104)",
-                height: "calc(var(--spacing) * 78)",
-              }}
-              className="rounded-lg object-cover shadow-lg"
+              className="h-78 w-104 rounded-lg object-cover shadow-lg"
             />
           </div>
           <div className="flex-1 space-y-4">
@@ -93,9 +94,19 @@ export const LibraryGameDetail = ({
             </div>
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <span className="text-muted-foreground font-medium">
-                  Story Progress
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground font-medium">
+                    Story progress
+                  </span>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <InfoIcon size={16} className="text-muted-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Proportion of pages visited out of all pages in the story
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
                 <span className="text-foreground text-2xl font-bold">
                   {progressPercentage}%
                 </span>


### PR DESCRIPTION
- Rend la page de détail d'un jeu responsive sur mobile
- Rend le titre de la dernière histoire jouée responsive sur la page d'accueil 
- Fix le builder démo sur la page d'accueil (les liens ne s'affichaient plus)
- Ajoute un tooltip explicatif sur la jauge de progression dans la page de détail 



Close #438 