### PR TITLE
Character conditional actions

### DIFF
--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -1,5 +1,5 @@
 import { Controller, FieldArrayWithId } from "react-hook-form";
-import { Button, FormItem, Input } from "@/design-system/primitives";
+import { Button, Input } from "@/design-system/primitives";
 import { SettingsIcon, Trash2Icon } from "lucide-react";
 import { FormError } from "@/design-system/components";
 import {
@@ -19,11 +19,7 @@ import {
 import { CharacterConfiguration } from "@/lib/storage/domain";
 import { match, P } from "ts-pattern";
 import { SceneSelector } from "./scene-selector";
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-} from "@/design-system/primitives/field";
+import { Field, FieldError } from "@/design-system/primitives/field";
 import { CharacterConditionFormSection } from "./character-condition-section";
 import {
   ALWAYS,

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -1,21 +1,12 @@
-import { FieldArrayWithId, UseFormStateReturn } from "react-hook-form";
+import { FieldArrayWithId } from "react-hook-form";
 import {
   Button,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
   FormControl,
   FormField,
   FormItem,
   Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
 } from "@/design-system/primitives";
-import { ChevronDown, SettingsIcon, Trash2Icon } from "lucide-react";
+import { SettingsIcon, Trash2Icon } from "lucide-react";
 import { FormError } from "@/design-system/components";
 import {
   Select,
@@ -27,85 +18,37 @@ import {
   SelectValue,
 } from "@/design-system/primitives/select";
 import { useState } from "react";
-import { Check } from "lucide-react";
-import { useGetBuilder } from "@/builder/hooks/use-get-builder";
 import { useBuilderContext } from "@/builder/hooks/use-builder-context";
-import { ScrollArea } from "@/design-system/primitives/scroll-area";
-import { capitalize } from "@/lib/string";
-import { cn } from "@/lib/style";
-import { SimpleLoader } from "@/design-system/components/simple-loader";
 import {
-  ActionSchema,
   EditActionsForm,
   EditActionsSchema,
 } from "@/builder/hooks/use-edit-actions-form";
+import { ConditionalAction, isSceneVisitCondition } from "@/lib/storage/domain";
+import { match, P } from "ts-pattern";
+import { SceneSelector } from "./scene-selector";
 
-const SceneSelector = ({
-  onChange,
-  value,
-}: {
-  onChange: (value?: string | null) => void;
-  value?: string | null;
-}) => {
-  const { story } = useBuilderContext();
-  const { scenes, isLoading } = useGetBuilder({ storyKey: story.key });
-  const [open, setOpen] = useState(false);
-  const selectedScene = scenes?.find((scene) => scene.key === value);
+// const useCondition = () => {
+//   const onConditionChange = (condition: Condition) => {
+//     setCondition(condition);
+//     match(condition)
+//       .with(P.union("user-did-visit", "user-did-not-visit"), () => {})
+//       .with("always", () => {})
+//       .exhaustive();
+//   };
+// };
 
-  return (
-    <>
-      <Popover open={open} onOpenChange={setOpen} modal={true}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-expanded={open}
-            className="text-foreground hover:text-foreground h-8! w-45 justify-between text-xs font-normal"
-          >
-            {value ? selectedScene?.title : "No scene"}
-            <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          className="w-full p-0 text-xs"
-          align="start"
-          side="bottom"
-        >
-          <Command>
-            <CommandInput placeholder="Search scenes..." />
-            <CommandList>
-              <ScrollArea className="h-37.5">
-                <CommandEmpty className="text-xs">No scene found.</CommandEmpty>
-                <CommandGroup>
-                  {scenes && !isLoading ? (
-                    scenes.map((scene) => (
-                      <CommandItem
-                        className="flex justify-between text-xs"
-                        key={scene.key}
-                        value={scene.key}
-                        onSelect={(value) => onChange(value)}
-                      >
-                        {capitalize(scene.title)}
-                        <Check
-                          className={cn(
-                            "h-4 w-4",
-                            value === scene.key ? "opacity-100" : "opacity-0",
-                          )}
-                        />
-                      </CommandItem>
-                    ))
-                  ) : (
-                    <SimpleLoader />
-                  )}
-                </CommandGroup>
-              </ScrollArea>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-    </>
-  );
-};
+const ALWAYS = "always";
+type Condition = ConditionalAction["condition"]["type"] | "always";
+
+const CONDITION_OPTIONS: {
+  value: Condition;
+  label: string;
+}[] = [
+  { value: ALWAYS, label: "Always" },
+  { value: "user-did-visit", label: "If player visited" },
+  { value: "user-did-not-visit", label: "If player did not visit" },
+  { value: "character-attribute", label: "If character's attribute..." }, // TODO: only show when character is set up with at least one attribute
+] as const;
 
 export const ActionItem = ({
   actionField,
@@ -124,27 +67,47 @@ export const ActionItem = ({
 }) => {
   const [openSettings, setOpenSettings] = useState(false);
   const { story } = useBuilderContext();
-  const [showCondition, setShowCondition] = useState(actionField.showCondition);
+  const [condition, setCondition] = useState<Condition>(
+    actionField.type === "conditional" ? actionField.condition.type : ALWAYS,
+  );
 
-  const onShowConditionChange = (
-    value: string,
-    formState: UseFormStateReturn<EditActionsSchema>,
-  ) => {
+  const onConditionChange = (condition: Condition) => {
+    const currentCondition = form.getValues(`actions.${index}.condition`);
+
     form.setValue(
-      `actions.${index}.showCondition`,
-      value as ActionSchema["showCondition"],
+      `actions.${index}.type`,
+      condition === "always" ? "simple" : "conditional",
     );
-    const hasTargetSceneKeyBeenModified =
-      formState.dirtyFields.actions?.[index] &&
-      "targetSceneKey" in formState.dirtyFields.actions[index];
 
-    if (value !== "always" && !hasTargetSceneKeyBeenModified) {
-      form.setValue(`actions.${index}.targetSceneKey`, story.firstSceneKey);
-    }
+    match(condition)
+      .with(P.union("user-did-visit", "user-did-not-visit"), (condition) => {
+        // Use first scene there is no current value for scene key
+        const sceneKey = isSceneVisitCondition(currentCondition)
+          ? currentCondition.sceneKey
+          : story.firstSceneKey;
+
+        form.setValue(`actions.${index}.condition`, {
+          type: condition,
+          sceneKey,
+        });
+      })
+      .with("character-attribute", (condition) => {
+        form.setValue(`actions.${index}.condition`, {
+          type: condition,
+          attributeKey: "", // TODO:
+          comparator: "greater-than",
+          value: 0,
+        });
+      })
+      .with("always", () => {
+        // TODO: do we need to do something to remove potential extra fields?
+      })
+      .exhaustive();
+
     // This is a workaround around the fact that:
     // 1. form.watch doesn't work with react compiler for now
     // 2. using form.setValue in a nested field of a field array doesn't trigger a rerender for the parent field
-    setShowCondition(value as ActionSchema["showCondition"]);
+    setCondition(condition);
   };
 
   return (
@@ -180,39 +143,25 @@ export const ActionItem = ({
           Show
           <FormField
             control={form.control}
-            name={`actions.${index}.showCondition`}
-            render={({ field, formState }) => (
+            name={`actions.${index}.condition.type`}
+            render={({ field }) => (
               <FormItem>
                 <FormControl>
                   <Select
-                    onValueChange={(value) =>
-                      onShowConditionChange(value, formState)
-                    }
-                    value={field.value}
+                    onValueChange={(value) => onConditionChange(value)}
+                    value={field.value ?? "always"}
                   >
                     <SelectTrigger className="h-8! w-45 *:data-[slot=select-value]:text-xs">
                       <SelectValue placeholder="Select a condition" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectGroup>
-                        <SelectLabel className="text-xs">
-                          Show this action
-                        </SelectLabel>
-                        <SelectItem className="text-xs" value="always">
-                          Always
-                        </SelectItem>
-                        <SelectItem
-                          className="text-xs"
-                          value="when-user-did-visit"
-                        >
-                          If player visited
-                        </SelectItem>
-                        <SelectItem
-                          className="text-xs"
-                          value="when-user-did-not-visit"
-                        >
-                          If player did not visit
-                        </SelectItem>
+                      <SelectGroup defaultValue="always">
+                        <SelectLabel>Show</SelectLabel>
+                        {CONDITION_OPTIONS.map(({ label, value }) => (
+                          <SelectItem className="text-xs" value={value}>
+                            {label}
+                          </SelectItem>
+                        ))}
                       </SelectGroup>
                     </SelectContent>
                   </Select>
@@ -220,22 +169,36 @@ export const ActionItem = ({
               </FormItem>
             )}
           />
-          {showCondition !== "always" && (
-            <FormField
-              control={form.control}
-              name={`actions.${index}.targetSceneKey`}
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <SceneSelector
-                      onChange={field.onChange}
-                      value={field.value}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-          )}
+          {match(condition)
+            .with(P.union("user-did-visit", "user-did-not-visit"), () => (
+              <FormField
+                control={form.control}
+                name={`actions.${index}.condition.sceneKey`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <SceneSelector
+                        onChange={field.onChange}
+                        value={field.value}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            ))
+            .with("character-attribute", () => (
+              <FormField
+                control={form.control}
+                name={`actions.${index}.condition.attributeKey`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>COUCOU</FormControl>
+                  </FormItem>
+                )}
+              />
+            ))
+            .with("always", () => null)
+            .exhaustive()}
         </div>
       )}
       {Object.entries(form.formState.errors.actions?.[index] ?? {}).map(

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -27,11 +27,22 @@ import {
   useConditionChange,
 } from "./hooks/use-condition-change";
 
-const CONDITION_OPTIONS: Record<Condition, string> = {
-  [ALWAYS]: "Always",
-  "user-did-visit": "If player visited",
-  "user-did-not-visit": "If player did not visit",
-  "character-attribute": "If character's attribute...", // TODO: only show when character is set up with at least one attribute
+const useConditionOptions = ({
+  hasCharacterConfig,
+}: {
+  hasCharacterConfig: boolean;
+}) => {
+  const options: Record<Condition, { label: string; disabled?: boolean }> = {
+    [ALWAYS]: { label: "Always" },
+    "user-did-visit": { label: "If player visited" },
+    "user-did-not-visit": { label: "If player did not visit" },
+    "character-attribute": {
+      label: "If character's attribute",
+      disabled: !hasCharacterConfig,
+    },
+  };
+
+  return options;
 };
 
 // TODO: test this
@@ -53,13 +64,18 @@ export const ActionItem = ({
   openRandomEventsSettings: () => void;
   closeRandomEventsSettings: () => void;
 }) => {
+  const hasCharacterConfig =
+    Object.keys(characterConfig?.attributes ?? {}).length > 0;
   const [openSettings, setOpenSettings] = useState(false);
+
   const { condition, onConditionChange } = useConditionChange({
     form,
     actionField,
     actionIndex,
     characterConfig,
+    hasCharacterConfig,
   });
+  const conditionOptions = useConditionOptions({ hasCharacterConfig });
 
   return (
     <div className="my-2" key={actionField.id}>
@@ -97,78 +113,75 @@ export const ActionItem = ({
         </Button>
       </div>
       {openSettings && (
-        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
-          Show
-          <Controller
-            control={form.control}
-            name={`actions.${actionIndex}.condition.type`}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid} className="w-max">
-                <Select
-                  onValueChange={(value) => onConditionChange(value)}
-                  value={field.value ?? "always"}
-                >
-                  <SelectTrigger className="*:data-[slot=select-value]:text-xs">
-                    <SelectValue placeholder="Select a condition" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup defaultValue="always">
-                      <SelectLabel>Show</SelectLabel>
-                      {Object.entries(CONDITION_OPTIONS).map(
-                        ([value, label]) => (
-                          <SelectItem className="text-xs" value={value}>
-                            {label}
-                          </SelectItem>
-                        ),
+        <div className="mt-2 flex flex-wrap items-center gap-1">
+          <p className="text-sm">Show</p>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <Select
+              onValueChange={(value) => onConditionChange(value)}
+              value={condition}
+            >
+              <SelectTrigger className="*:data-[slot=select-value]:text-xs">
+                <SelectValue placeholder="Select a condition" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectLabel>Show</SelectLabel>
+                  {Object.entries(conditionOptions).map(
+                    ([value, { label, disabled }]) => (
+                      <SelectItem
+                        key={value}
+                        className="text-xs"
+                        value={value}
+                        disabled={disabled}
+                      >
+                        {label}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {match(condition)
+              .with(P.union("user-did-visit", "user-did-not-visit"), () => (
+                <Controller
+                  control={form.control}
+                  name={`actions.${actionIndex}.condition.sceneKey`}
+                  render={({ field, fieldState }) => (
+                    <Field data-invalid={fieldState.invalid} className="w-max">
+                      <SceneSelector
+                        onChange={field.onChange}
+                        value={field.value}
+                      />
+                      {fieldState.invalid && (
+                        <FieldError errors={[fieldState.error]} />
                       )}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-                {fieldState.invalid && (
-                  <FieldError errors={[fieldState.error]} />
-                )}
-              </Field>
-            )}
-          />
-          {match(condition)
-            .with(P.union("user-did-visit", "user-did-not-visit"), () => (
-              <Controller
-                control={form.control}
-                name={`actions.${actionIndex}.condition.sceneKey`}
-                render={({ field, fieldState }) => (
-                  <Field data-invalid={fieldState.invalid} className="w-max">
-                    <SceneSelector
-                      onChange={field.onChange}
-                      value={field.value}
-                    />
-                    {fieldState.invalid && (
-                      <FieldError errors={[fieldState.error]} />
-                    )}
-                  </Field>
-                )}
-              />
-            ))
-            .with("character-attribute", () => {
-              if (!characterConfig)
-                throw new Error(
-                  `Cannot render character condition form if no character exists in story`,
-                );
-              return (
-                <CharacterConditionFormSection
-                  form={form}
-                  actionIndex={actionIndex}
-                  characterConfig={characterConfig}
+                    </Field>
+                  )}
                 />
-              );
-            })
-            .with("always", () => null)
-            .exhaustive()}
+              ))
+              .with("character-attribute", () => {
+                if (!characterConfig)
+                  throw new Error(
+                    `Cannot render character condition form if no character exists in story`,
+                  );
+                return (
+                  <CharacterConditionFormSection
+                    form={form}
+                    actionIndex={actionIndex}
+                    characterConfig={characterConfig}
+                  />
+                );
+              })
+              .with("always", () => null)
+              .exhaustive()}
+          </div>
         </div>
       )}
+      {/* TODO: improve error messages */}
       {Object.entries(form.formState.errors.actions?.[actionIndex] ?? {}).map(
         ([_fieldName, error]) =>
           error ? (
-            <FormError className="text-xs">
+            <FormError className="text-xs" key={`${_fieldName}-error`}>
               {typeof error === "string"
                 ? error
                 : "message" in error

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -60,7 +60,7 @@ const SceneSelector = ({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="text-foreground hover:text-foreground h-8! w-[180px] justify-between text-xs font-normal"
+            className="text-foreground hover:text-foreground h-8! w-45 justify-between text-xs font-normal"
           >
             {value ? selectedScene?.title : "No scene"}
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -74,7 +74,7 @@ const SceneSelector = ({
           <Command>
             <CommandInput placeholder="Search scenes..." />
             <CommandList>
-              <ScrollArea className="h-[150px]">
+              <ScrollArea className="h-37.5">
                 <CommandEmpty className="text-xs">No scene found.</CommandEmpty>
                 <CommandGroup>
                   {scenes && !isLoading ? (
@@ -190,7 +190,7 @@ export const ActionItem = ({
                     }
                     value={field.value}
                   >
-                    <SelectTrigger className="h-8! w-[180px] *:data-[slot=select-value]:text-xs">
+                    <SelectTrigger className="h-8! w-45 *:data-[slot=select-value]:text-xs">
                       <SelectValue placeholder="Select a condition" />
                     </SelectTrigger>
                     <SelectContent>

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -1,11 +1,5 @@
-import { FieldArrayWithId } from "react-hook-form";
-import {
-  Button,
-  FormControl,
-  FormField,
-  FormItem,
-  Input,
-} from "@/design-system/primitives";
+import { Controller, FieldArrayWithId } from "react-hook-form";
+import { Button, FormItem, Input } from "@/design-system/primitives";
 import { SettingsIcon, Trash2Icon } from "lucide-react";
 import { FormError } from "@/design-system/components";
 import {
@@ -18,105 +12,73 @@ import {
   SelectValue,
 } from "@/design-system/primitives/select";
 import { useState } from "react";
-import { useBuilderContext } from "@/builder/hooks/use-builder-context";
 import {
   EditActionsForm,
   EditActionsSchema,
 } from "@/builder/hooks/use-edit-actions-form";
-import { ConditionalAction, isSceneVisitCondition } from "@/lib/storage/domain";
+import { CharacterConfiguration } from "@/lib/storage/domain";
 import { match, P } from "ts-pattern";
 import { SceneSelector } from "./scene-selector";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+} from "@/design-system/primitives/field";
+import { CharacterConditionFormSection } from "./character-condition-section";
+import {
+  ALWAYS,
+  Condition,
+  useConditionChange,
+} from "./hooks/use-condition-change";
 
-// const useCondition = () => {
-//   const onConditionChange = (condition: Condition) => {
-//     setCondition(condition);
-//     match(condition)
-//       .with(P.union("user-did-visit", "user-did-not-visit"), () => {})
-//       .with("always", () => {})
-//       .exhaustive();
-//   };
-// };
+const CONDITION_OPTIONS: Record<Condition, string> = {
+  [ALWAYS]: "Always",
+  "user-did-visit": "If player visited",
+  "user-did-not-visit": "If player did not visit",
+  "character-attribute": "If character's attribute...", // TODO: only show when character is set up with at least one attribute
+};
 
-const ALWAYS = "always";
-type Condition = ConditionalAction["condition"]["type"] | "always";
-
-const CONDITION_OPTIONS: {
-  value: Condition;
-  label: string;
-}[] = [
-  { value: ALWAYS, label: "Always" },
-  { value: "user-did-visit", label: "If player visited" },
-  { value: "user-did-not-visit", label: "If player did not visit" },
-  { value: "character-attribute", label: "If character's attribute..." }, // TODO: only show when character is set up with at least one attribute
-] as const;
-
+// TODO: test this
+// TODO: selectors have horrendous performance on open, we should dig into it
 export const ActionItem = ({
   actionField,
   form,
-  index,
+  actionIndex,
+  characterConfig,
   removeAction,
   openRandomEventsSettings,
   closeRandomEventsSettings,
 }: {
   actionField: FieldArrayWithId<EditActionsSchema, "actions", "id">;
   form: EditActionsForm;
-  index: number;
+  actionIndex: number;
+  characterConfig: CharacterConfiguration | null;
   removeAction: (index: number) => void;
   openRandomEventsSettings: () => void;
   closeRandomEventsSettings: () => void;
 }) => {
   const [openSettings, setOpenSettings] = useState(false);
-  const { story } = useBuilderContext();
-  const [condition, setCondition] = useState<Condition>(
-    actionField.type === "conditional" ? actionField.condition.type : ALWAYS,
-  );
-
-  const onConditionChange = (condition: Condition) => {
-    const currentCondition = form.getValues(`actions.${index}.condition`);
-
-    form.setValue(
-      `actions.${index}.type`,
-      condition === "always" ? "simple" : "conditional",
-    );
-
-    match(condition)
-      .with(P.union("user-did-visit", "user-did-not-visit"), (condition) => {
-        // Use first scene there is no current value for scene key
-        const sceneKey = isSceneVisitCondition(currentCondition)
-          ? currentCondition.sceneKey
-          : story.firstSceneKey;
-
-        form.setValue(`actions.${index}.condition`, {
-          type: condition,
-          sceneKey,
-        });
-      })
-      .with("character-attribute", (condition) => {
-        form.setValue(`actions.${index}.condition`, {
-          type: condition,
-          attributeKey: "", // TODO:
-          comparator: "greater-than",
-          value: 0,
-        });
-      })
-      .with("always", () => {
-        // TODO: do we need to do something to remove potential extra fields?
-      })
-      .exhaustive();
-
-    // This is a workaround around the fact that:
-    // 1. form.watch doesn't work with react compiler for now
-    // 2. using form.setValue in a nested field of a field array doesn't trigger a rerender for the parent field
-    setCondition(condition);
-  };
+  const { condition, onConditionChange } = useConditionChange({
+    form,
+    actionField,
+    actionIndex,
+    characterConfig,
+  });
 
   return (
-    <FormItem className="my-2" key={actionField.id}>
+    <div className="my-2" key={actionField.id}>
       <div className="flex items-center gap-2">
-        <Input
-          placeholder="Go to the village"
-          {...form.register(`actions.${index}.text` as const)}
+        <Controller
+          control={form.control}
+          name={`actions.${actionIndex}.text`}
+          render={({ field, fieldState }) => (
+            <Field data-invalid={fieldState.invalid} className="w-full">
+              <Input {...field} placeholder="Go to the village" />
+              {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+            </Field>
+          )}
         />
+
         <Button
           variant="outline"
           size="icon"
@@ -133,75 +95,81 @@ export const ActionItem = ({
           variant="outline"
           size="icon"
           type="button"
-          onClick={() => removeAction(index)}
+          onClick={() => removeAction(actionIndex)}
         >
           <Trash2Icon />
         </Button>
       </div>
       {openSettings && (
-        <div className="flex items-center gap-2 text-sm">
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
           Show
-          <FormField
+          <Controller
             control={form.control}
-            name={`actions.${index}.condition.type`}
-            render={({ field }) => (
-              <FormItem>
-                <FormControl>
-                  <Select
-                    onValueChange={(value) => onConditionChange(value)}
-                    value={field.value ?? "always"}
-                  >
-                    <SelectTrigger className="h-8! w-45 *:data-[slot=select-value]:text-xs">
-                      <SelectValue placeholder="Select a condition" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup defaultValue="always">
-                        <SelectLabel>Show</SelectLabel>
-                        {CONDITION_OPTIONS.map(({ label, value }) => (
+            name={`actions.${actionIndex}.condition.type`}
+            render={({ field, fieldState }) => (
+              <Field data-invalid={fieldState.invalid} className="w-max">
+                <Select
+                  onValueChange={(value) => onConditionChange(value)}
+                  value={field.value ?? "always"}
+                >
+                  <SelectTrigger className="*:data-[slot=select-value]:text-xs">
+                    <SelectValue placeholder="Select a condition" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup defaultValue="always">
+                      <SelectLabel>Show</SelectLabel>
+                      {Object.entries(CONDITION_OPTIONS).map(
+                        ([value, label]) => (
                           <SelectItem className="text-xs" value={value}>
                             {label}
                           </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </FormControl>
-              </FormItem>
+                        ),
+                      )}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+                {fieldState.invalid && (
+                  <FieldError errors={[fieldState.error]} />
+                )}
+              </Field>
             )}
           />
           {match(condition)
             .with(P.union("user-did-visit", "user-did-not-visit"), () => (
-              <FormField
+              <Controller
                 control={form.control}
-                name={`actions.${index}.condition.sceneKey`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <SceneSelector
-                        onChange={field.onChange}
-                        value={field.value}
-                      />
-                    </FormControl>
-                  </FormItem>
+                name={`actions.${actionIndex}.condition.sceneKey`}
+                render={({ field, fieldState }) => (
+                  <Field data-invalid={fieldState.invalid} className="w-max">
+                    <SceneSelector
+                      onChange={field.onChange}
+                      value={field.value}
+                    />
+                    {fieldState.invalid && (
+                      <FieldError errors={[fieldState.error]} />
+                    )}
+                  </Field>
                 )}
               />
             ))
-            .with("character-attribute", () => (
-              <FormField
-                control={form.control}
-                name={`actions.${index}.condition.attributeKey`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>COUCOU</FormControl>
-                  </FormItem>
-                )}
-              />
-            ))
+            .with("character-attribute", () => {
+              if (!characterConfig)
+                throw new Error(
+                  `Cannot render character condition form if no character exists in story`,
+                );
+              return (
+                <CharacterConditionFormSection
+                  form={form}
+                  actionIndex={actionIndex}
+                  characterConfig={characterConfig}
+                />
+              );
+            })
             .with("always", () => null)
             .exhaustive()}
         </div>
       )}
-      {Object.entries(form.formState.errors.actions?.[index] ?? {}).map(
+      {Object.entries(form.formState.errors.actions?.[actionIndex] ?? {}).map(
         ([_fieldName, error]) =>
           error ? (
             <FormError className="text-xs">
@@ -213,6 +181,6 @@ export const ActionItem = ({
             </FormError>
           ) : null,
       )}
-    </FormItem>
+    </div>
   );
 };

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -26,6 +26,7 @@ import {
   Condition,
   useConditionChange,
 } from "./hooks/use-condition-change";
+import { Separator } from "@/design-system/primitives/separator";
 
 const useConditionOptions = ({
   hasCharacterConfig,
@@ -46,7 +47,6 @@ const useConditionOptions = ({
 };
 
 // TODO: test this
-// TODO: selectors have horrendous performance on open, we should dig into it
 export const ActionItem = ({
   actionField,
   form,
@@ -67,6 +67,14 @@ export const ActionItem = ({
   const hasCharacterConfig =
     Object.keys(characterConfig?.attributes ?? {}).length > 0;
   const [openSettings, setOpenSettings] = useState(false);
+
+  const toggleSettings = () => {
+    setOpenSettings((prev) => {
+      // Clear form errors when closing settings since erroneous values will be discarded
+      if (prev) form.clearErrors();
+      return !prev;
+    });
+  };
 
   const { condition, onConditionChange } = useConditionChange({
     form,
@@ -96,7 +104,7 @@ export const ActionItem = ({
           size="icon"
           type="button"
           onClick={() => {
-            setOpenSettings((prev) => !prev);
+            toggleSettings();
             if (openSettings) closeRandomEventsSettings();
             else openRandomEventsSettings();
           }}
@@ -113,7 +121,7 @@ export const ActionItem = ({
         </Button>
       </div>
       {openSettings && (
-        <div className="mt-2 flex flex-wrap items-center gap-1">
+        <div className="mt-2 flex flex-wrap items-center gap-1 pl-2">
           <p className="text-sm">Show</p>
           <div className="flex flex-wrap items-center gap-2 text-sm">
             <Select
@@ -152,9 +160,6 @@ export const ActionItem = ({
                         onChange={field.onChange}
                         value={field.value}
                       />
-                      {fieldState.invalid && (
-                        <FieldError errors={[fieldState.error]} />
-                      )}
                     </Field>
                   )}
                 />
@@ -175,20 +180,25 @@ export const ActionItem = ({
               .with("always", () => null)
               .exhaustive()}
           </div>
+          {Object.values(
+            form.formState.errors.actions?.[actionIndex] ?? {},
+          ).map((actionErrors) => {
+            if (typeof actionErrors === "string") return null;
+
+            return Object.entries(actionErrors).map(([fieldName, error]) =>
+              error ? (
+                <FormError className="text-xs" key={`${fieldName}-error`}>
+                  {typeof error === "string"
+                    ? error
+                    : "message" in error
+                      ? error.message
+                      : null}
+                </FormError>
+              ) : null,
+            );
+          })}
+          <Separator className="my-2" />
         </div>
-      )}
-      {/* TODO: improve error messages */}
-      {Object.entries(form.formState.errors.actions?.[actionIndex] ?? {}).map(
-        ([_fieldName, error]) =>
-          error ? (
-            <FormError className="text-xs" key={`${_fieldName}-error`}>
-              {typeof error === "string"
-                ? error
-                : "message" in error
-                  ? error.message
-                  : null}
-            </FormError>
-          ) : null,
       )}
     </div>
   );

--- a/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
@@ -35,11 +35,10 @@ const useRandomEventsToolbar = ({ scene }: { scene: Scene }) => {
 
 const ActionsFormContent = ({ scene }: { scene: Scene }) => {
   const { updateScene, makeEmptyActionPayload } = useBuilderActions();
-  const { append, fields, form, remove, adaptDomainAction } =
-    useEditActionsForm({
-      actions: scene.actions,
-      onSave: (payload) => updateScene({ key: scene.key, ...payload }),
-    });
+  const { append, fields, form, remove } = useEditActionsForm({
+    actions: scene.actions,
+    onSave: (payload) => updateScene({ key: scene.key, ...payload }),
+  });
 
   const removeAction = (index?: number | number[]) => {
     closeRandomEventsToolbar();
@@ -70,9 +69,7 @@ const ActionsFormContent = ({ scene }: { scene: Scene }) => {
                   variant="ghost"
                   type="button"
                   size="icon"
-                  onClick={() =>
-                    append(adaptDomainAction(makeEmptyActionPayload()))
-                  }
+                  onClick={() => append(makeEmptyActionPayload())}
                 >
                   <PlusIcon />
                 </Button>
@@ -107,6 +104,7 @@ const ActionsFormContent = ({ scene }: { scene: Scene }) => {
 
 export const ActionsFormContainer = ({ sceneKey }: { sceneKey: string }) => {
   const { scene, isLoading } = useGetScene(sceneKey);
+  // const {characterConfig, isCharacterLoading} = useGetC
 
   if (isLoading || scene === undefined) return <SimpleLoader />;
 

--- a/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
@@ -1,6 +1,5 @@
 import { Button, Form, FormDescription } from "@/design-system/primitives";
 import { PlusIcon } from "lucide-react";
-import { ActionItem } from "./action-item";
 import { useEditActionsForm } from "@/builder/hooks/use-edit-actions-form";
 import { Toolbar } from "@/design-system/components/toolbar";
 import {
@@ -10,8 +9,10 @@ import {
 import { useBuilderActions } from "@/builder/hooks/use-builder-actions";
 import { useGetScene } from "@/builder/hooks/use-get-scene";
 import { SimpleLoader } from "@/design-system/components/simple-loader";
-import { Scene } from "@/lib/storage/domain";
+import { CharacterConfiguration, Scene } from "@/lib/storage/domain";
 import { useState } from "react";
+import { useGetCharacterConfig } from "@/builder/hooks/use-get-character-config";
+import { ActionItem } from "./action-item";
 
 const useRandomEventsToolbar = ({ scene }: { scene: Scene }) => {
   const [randomEventsActionKey, setRandomEventsActionKey] = useState<
@@ -33,7 +34,13 @@ const useRandomEventsToolbar = ({ scene }: { scene: Scene }) => {
   };
 };
 
-const ActionsFormContent = ({ scene }: { scene: Scene }) => {
+const ActionsFormContent = ({
+  scene,
+  characterConfig,
+}: {
+  scene: Scene;
+  characterConfig: CharacterConfiguration | null;
+}) => {
   const { updateScene, makeEmptyActionPayload } = useBuilderActions();
   const { append, fields, form, remove } = useEditActionsForm({
     actions: scene.actions,
@@ -81,12 +88,13 @@ const ActionsFormContent = ({ scene }: { scene: Scene }) => {
               Buttons that allow the player to move in your story
             </FormDescription>
             <div>
-              {fields.map((field, index) => (
+              {fields.map((field, actionIndex) => (
                 <ActionItem
                   key={field.id}
                   actionField={field}
                   form={form}
-                  index={index}
+                  actionIndex={actionIndex}
+                  characterConfig={characterConfig}
                   removeAction={removeAction}
                   openRandomEventsSettings={() =>
                     openRandomEventsToolbar(field.key)
@@ -104,9 +112,16 @@ const ActionsFormContent = ({ scene }: { scene: Scene }) => {
 
 export const ActionsFormContainer = ({ sceneKey }: { sceneKey: string }) => {
   const { scene, isLoading } = useGetScene(sceneKey);
-  // const {characterConfig, isCharacterLoading} = useGetC
+  const { characterConfig, isLoading: isCharacterLoading } =
+    useGetCharacterConfig();
 
-  if (isLoading || scene === undefined) return <SimpleLoader />;
+  if (
+    isLoading ||
+    scene === undefined ||
+    isCharacterLoading ||
+    characterConfig === undefined
+  )
+    return <SimpleLoader />;
 
-  return <ActionsFormContent scene={scene} />;
+  return <ActionsFormContent scene={scene} characterConfig={characterConfig} />;
 };

--- a/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
@@ -12,7 +12,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/design-system/primitives";
-import { Field, FieldError } from "@/design-system/primitives/field";
+import { Field } from "@/design-system/primitives/field";
 import { ScrollArea } from "@/design-system/primitives/scroll-area";
 import {
   Select,
@@ -108,7 +108,6 @@ const CHARACTER_ATTR_COMPARATOR_OPTIONS: Record<
   string
 > = { "greater-than": "is greater than", "lower-than": "is lower than" };
 
-// TODO: handle errors in prettier way
 export const CharacterConditionFormSection = ({
   form,
   actionIndex,
@@ -130,7 +129,6 @@ export const CharacterConditionFormSection = ({
               onChange={field.onChange}
               value={field.value}
             />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}
       />
@@ -158,7 +156,6 @@ export const CharacterConditionFormSection = ({
                 </SelectGroup>
               </SelectContent>
             </Select>
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}
       />
@@ -172,7 +169,6 @@ export const CharacterConditionFormSection = ({
               defaultValue={field.value}
               className="text-xs!"
             />
-            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}
       />

--- a/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
@@ -166,11 +166,12 @@ export const CharacterConditionFormSection = ({
         control={form.control}
         name={`actions.${actionIndex}.condition.value`}
         render={({ field, fieldState }) => (
-          <Field
-            data-invalid={fieldState.invalid}
-            className="h-8 max-w-12 text-xs!"
-          >
-            <NumberInput onChange={field.onChange} defaultValue={field.value} />
+          <Field data-invalid={fieldState.invalid} className="h-8 max-w-10">
+            <NumberInput
+              onChange={field.onChange}
+              defaultValue={field.value}
+              className="text-xs!"
+            />
             {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
           </Field>
         )}

--- a/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/character-condition-section.tsx
@@ -1,0 +1,180 @@
+import { EditActionsForm } from "@/builder/hooks/use-edit-actions-form";
+import { NumberInput } from "@/design-system/components/number-input";
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/design-system/primitives";
+import { Field, FieldError } from "@/design-system/primitives/field";
+import { ScrollArea } from "@/design-system/primitives/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/design-system/primitives/select";
+import {
+  CharacterAttributeCondition,
+  CharacterConfiguration,
+} from "@/lib/storage/domain";
+import { capitalize } from "@/lib/string";
+import { cn } from "@/lib/style";
+import { Check, ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { Controller } from "react-hook-form";
+
+const CharacterAttributeSelector = ({
+  onChange,
+  value,
+  characterConfig,
+}: {
+  onChange: (attributeKey?: string | null) => void;
+  value?: string | null;
+  characterConfig: CharacterConfiguration;
+}) => {
+  const [open, setOpen] = useState(false);
+  const selectedAttr = value
+    ? (characterConfig.attributes[value] ?? null)
+    : null;
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="text-foreground hover:text-foreground justify-between text-xs font-normal"
+          >
+            {value ? selectedAttr?.name : "No attribute"}
+            <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-full p-0 text-xs"
+          align="start"
+          side="bottom"
+        >
+          <Command>
+            <CommandInput placeholder="Search attributes..." />
+            <CommandList>
+              <ScrollArea className="h-37.5">
+                <CommandEmpty className="text-xs">
+                  No attribute found.
+                </CommandEmpty>
+                <CommandGroup>
+                  {Object.values(characterConfig.attributes).map(
+                    (attribute) => (
+                      <CommandItem
+                        className="flex justify-between text-xs"
+                        key={attribute.key}
+                        value={attribute.key}
+                        onSelect={(value) => onChange(value)}
+                      >
+                        {capitalize(attribute.name)}
+                        <Check
+                          className={cn(
+                            "h-4 w-4",
+                            value === attribute.key
+                              ? "opacity-100"
+                              : "opacity-0",
+                          )}
+                        />
+                      </CommandItem>
+                    ),
+                  )}
+                </CommandGroup>
+              </ScrollArea>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+};
+
+const CHARACTER_ATTR_COMPARATOR_OPTIONS: Record<
+  CharacterAttributeCondition["comparator"],
+  string
+> = { "greater-than": "is greater than", "lower-than": "is lower than" };
+
+// TODO: handle errors in prettier way
+export const CharacterConditionFormSection = ({
+  form,
+  actionIndex,
+  characterConfig,
+}: {
+  form: EditActionsForm;
+  actionIndex: number;
+  characterConfig: CharacterConfiguration;
+}) => {
+  return (
+    <>
+      <Controller
+        control={form.control}
+        name={`actions.${actionIndex}.condition.attributeKey`}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid} className="w-max">
+            <CharacterAttributeSelector
+              characterConfig={characterConfig}
+              onChange={field.onChange}
+              value={field.value}
+            />
+            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+      <Controller
+        control={form.control}
+        name={`actions.${actionIndex}.condition.comparator`}
+        render={({ field, fieldState }) => (
+          <Field data-invalid={fieldState.invalid} className="w-max">
+            <Select
+              onValueChange={field.onChange}
+              value={field.value ?? "always"}
+            >
+              <SelectTrigger className="*:data-[slot=select-value]:text-xs">
+                <SelectValue placeholder="Select a condition" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup defaultValue="">
+                  {Object.entries(CHARACTER_ATTR_COMPARATOR_OPTIONS).map(
+                    ([value, label]) => (
+                      <SelectItem className="text-xs" value={value}>
+                        {label}
+                      </SelectItem>
+                    ),
+                  )}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+      <Controller
+        control={form.control}
+        name={`actions.${actionIndex}.condition.value`}
+        render={({ field, fieldState }) => (
+          <Field
+            data-invalid={fieldState.invalid}
+            className="h-8 max-w-12 text-xs!"
+          >
+            <NumberInput onChange={field.onChange} defaultValue={field.value} />
+            {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
+          </Field>
+        )}
+      />
+    </>
+  );
+};

--- a/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
@@ -24,7 +24,6 @@ const conditionSchema = z.union([
 ]);
 
 function assertIsCondition(value: string): asserts value is Condition {
-  // This will throw
   conditionSchema.parse(value);
 }
 
@@ -34,14 +33,14 @@ export const useConditionChange = ({
   actionField,
   actionIndex,
   characterConfig,
+  hasCharacterConfig,
 }: {
   form: EditActionsForm;
   actionField: FieldArrayWithId<EditActionsSchema, "actions", "id">;
   actionIndex: number;
   characterConfig: CharacterConfiguration | null;
+  hasCharacterConfig: boolean;
 }) => {
-  const isCharacterConfigured =
-    Object.keys(characterConfig?.attributes ?? {}).length > 0;
   const { story } = useBuilderContext();
   const [condition, setCondition] = useState<Condition>(
     actionField.type === "conditional" ? actionField.condition.type : ALWAYS,
@@ -49,41 +48,51 @@ export const useConditionChange = ({
 
   const onConditionChange = (condition: string) => {
     assertIsCondition(condition);
-    const currentCondition = form.getValues(`actions.${actionIndex}.condition`);
-
-    form.setValue(
-      `actions.${actionIndex}.type`,
-      condition === "always" ? "simple" : "conditional",
-    );
+    const currentAction = form.getValues(`actions.${actionIndex}`);
+    const commonFields = {
+      key: currentAction.key,
+      targets: currentAction.targets,
+      text: currentAction.text,
+    };
 
     match(condition)
       .with(P.union("user-did-visit", "user-did-not-visit"), (condition) => {
-        // Use first scene there is no current value for scene key
-        const sceneKey = isSceneVisitCondition(currentCondition)
-          ? currentCondition.sceneKey
-          : story.firstSceneKey;
+        const isConditionAction = currentAction.type === "conditional";
+        // Use first scene if there is no current value for scene key
+        const sceneKey =
+          isConditionAction && isSceneVisitCondition(currentAction.condition)
+            ? currentAction.condition.sceneKey
+            : story.firstSceneKey;
 
-        form.setValue(`actions.${actionIndex}.condition`, {
-          type: condition,
-          sceneKey,
+        form.setValue(`actions.${actionIndex}`, {
+          ...commonFields,
+          type: "conditional",
+          condition: { type: condition, sceneKey },
         });
       })
       .with("character-attribute", (condition) => {
         // This should never happen
-        if (!isCharacterConfigured)
+        if (!hasCharacterConfig)
           throw new Error(
             `Cannot setup conditional on character if no character exists in story`,
           );
 
-        form.setValue(`actions.${actionIndex}.condition`, {
-          type: condition,
-          attributeKey: Object.keys(characterConfig!.attributes)[0]!, // Random key in character's attributes
-          comparator: "greater-than",
-          value: 0,
+        form.setValue(`actions.${actionIndex}`, {
+          ...commonFields,
+          type: "conditional",
+          condition: {
+            type: condition,
+            attributeKey: Object.keys(characterConfig!.attributes)[0]!, // Random key in character's attributes
+            comparator: "greater-than",
+            value: 0,
+          },
         });
       })
       .with("always", () => {
-        // TODO: do we need to do something to remove potential extra fields?
+        form.setValue(`actions.${actionIndex}`, {
+          ...commonFields,
+          type: "simple",
+        });
       })
       .exhaustive();
 

--- a/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
@@ -1,0 +1,83 @@
+import { useBuilderContext } from "@/builder/hooks/use-builder-context";
+import {
+  EditActionsForm,
+  EditActionsSchema,
+} from "@/builder/hooks/use-edit-actions-form";
+import {
+  CharacterConfiguration,
+  ConditionalAction,
+  isSceneVisitCondition,
+} from "@/lib/storage/domain";
+import { useState } from "react";
+import { FieldArrayWithId } from "react-hook-form";
+import { match, P } from "ts-pattern";
+
+export const ALWAYS = "always";
+export type Condition = ConditionalAction["condition"]["type"] | "always";
+
+// TODO: test this
+export const useConditionChange = ({
+  form,
+  actionField,
+  actionIndex,
+  characterConfig,
+}: {
+  form: EditActionsForm;
+  actionField: FieldArrayWithId<EditActionsSchema, "actions", "id">;
+  actionIndex: number;
+  characterConfig: CharacterConfiguration | null;
+}) => {
+  const isCharacterConfigured =
+    Object.keys(characterConfig?.attributes ?? {}).length > 0;
+  const { story } = useBuilderContext();
+  const [condition, setCondition] = useState<Condition>(
+    actionField.type === "conditional" ? actionField.condition.type : ALWAYS,
+  );
+
+  const onConditionChange = (condition: Condition) => {
+    const currentCondition = form.getValues(`actions.${actionIndex}.condition`);
+
+    form.setValue(
+      `actions.${actionIndex}.type`,
+      condition === "always" ? "simple" : "conditional",
+    );
+
+    match(condition)
+      .with(P.union("user-did-visit", "user-did-not-visit"), (condition) => {
+        // Use first scene there is no current value for scene key
+        const sceneKey = isSceneVisitCondition(currentCondition)
+          ? currentCondition.sceneKey
+          : story.firstSceneKey;
+
+        form.setValue(`actions.${actionIndex}.condition`, {
+          type: condition,
+          sceneKey,
+        });
+      })
+      .with("character-attribute", (condition) => {
+        // This should never happen
+        if (!isCharacterConfigured)
+          throw new Error(
+            `Cannot setup conditional on character if no character exists in story`,
+          );
+
+        form.setValue(`actions.${actionIndex}.condition`, {
+          type: condition,
+          attributeKey: Object.keys(characterConfig!.attributes)[0]!, // Random key in character's attributes
+          comparator: "greater-than",
+          value: 0,
+        });
+      })
+      .with("always", () => {
+        // TODO: do we need to do something to remove potential extra fields?
+      })
+      .exhaustive();
+
+    // This is a workaround around the fact that:
+    // 1. form.watch doesn't work with react compiler for now
+    // 2. using form.setValue in a nested field of a field array doesn't trigger a rerender for the parent field
+    setCondition(condition);
+  };
+
+  return { condition, onConditionChange };
+};

--- a/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/hooks/use-condition-change.ts
@@ -11,9 +11,22 @@ import {
 import { useState } from "react";
 import { FieldArrayWithId } from "react-hook-form";
 import { match, P } from "ts-pattern";
+import z from "zod";
 
 export const ALWAYS = "always";
 export type Condition = ConditionalAction["condition"]["type"] | "always";
+
+const conditionSchema = z.union([
+  z.literal("always"),
+  z.literal("user-did-visit"),
+  z.literal("user-did-not-visit"),
+  z.literal("character-attribute"),
+]);
+
+function assertIsCondition(value: string): asserts value is Condition {
+  // This will throw
+  conditionSchema.parse(value);
+}
 
 // TODO: test this
 export const useConditionChange = ({
@@ -34,7 +47,8 @@ export const useConditionChange = ({
     actionField.type === "conditional" ? actionField.condition.type : ALWAYS,
   );
 
-  const onConditionChange = (condition: Condition) => {
+  const onConditionChange = (condition: string) => {
+    assertIsCondition(condition);
     const currentCondition = form.getValues(`actions.${actionIndex}.condition`);
 
     form.setValue(

--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-selector.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-selector.tsx
@@ -1,0 +1,87 @@
+import { useBuilderContext } from "@/builder/hooks/use-builder-context";
+import { useGetBuilder } from "@/builder/hooks/use-get-builder";
+import { SimpleLoader } from "@/design-system/components/simple-loader";
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/design-system/primitives";
+import { ScrollArea } from "@/design-system/primitives/scroll-area";
+import { capitalize } from "@/lib/string";
+import { cn } from "@/lib/style";
+import { Check, ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+export const SceneSelector = ({
+  onChange,
+  value,
+}: {
+  onChange: (value?: string | null) => void;
+  value?: string | null;
+}) => {
+  const { story } = useBuilderContext();
+  const { scenes, isLoading } = useGetBuilder({ storyKey: story.key });
+  const [open, setOpen] = useState(false);
+  const selectedScene = scenes?.find((scene) => scene.key === value);
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen} modal={true}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="text-foreground hover:text-foreground h-8! w-45 justify-between text-xs font-normal"
+          >
+            {value ? selectedScene?.title : "No scene"}
+            <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-full p-0 text-xs"
+          align="start"
+          side="bottom"
+        >
+          <Command>
+            <CommandInput placeholder="Search scenes..." />
+            <CommandList>
+              <ScrollArea className="h-37.5">
+                <CommandEmpty className="text-xs">No scene found.</CommandEmpty>
+                <CommandGroup>
+                  {scenes && !isLoading ? (
+                    scenes.map((scene) => (
+                      <CommandItem
+                        className="flex justify-between text-xs"
+                        key={scene.key}
+                        value={scene.key}
+                        onSelect={(value) => onChange(value)}
+                      >
+                        {capitalize(scene.title)}
+                        <Check
+                          className={cn(
+                            "h-4 w-4",
+                            value === scene.key ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                      </CommandItem>
+                    ))
+                  ) : (
+                    <SimpleLoader />
+                  )}
+                </CommandGroup>
+              </ScrollArea>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+};

--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-selector.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-selector.tsx
@@ -39,7 +39,7 @@ export const SceneSelector = ({
             variant="outline"
             role="combobox"
             aria-expanded={open}
-            className="text-foreground hover:text-foreground h-8! w-45 justify-between text-xs font-normal"
+            className="text-foreground hover:text-foreground justify-between text-xs font-normal"
           >
             {value ? selectedScene?.title : "No scene"}
             <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -5,8 +5,6 @@ import z from "zod";
 import { useAutoSubmitForm } from "@/hooks/use-auto-submit-form";
 import { actionSchema } from "@/lib/action-schema";
 
-export type ActionSchema = z.infer<typeof actionSchema>;
-
 const schema = z.object({ actions: z.array(actionSchema) });
 
 export type EditActionsSchema = z.infer<typeof schema>;

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -7,7 +7,7 @@ import { actionSchema } from "@/lib/action-schema";
 
 const schema = z.object({ actions: z.array(actionSchema) });
 
-export type EditActionsSchemaInput = z.input<typeof schema>;
+type EditActionsSchemaInput = z.input<typeof schema>;
 export type EditActionsSchema = z.output<typeof schema>;
 
 export const useEditActionsForm = ({

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -7,7 +7,8 @@ import { actionSchema } from "@/lib/action-schema";
 
 const schema = z.object({ actions: z.array(actionSchema) });
 
-export type EditActionsSchema = z.infer<typeof schema>;
+export type EditActionsSchemaInput = z.input<typeof schema>;
+export type EditActionsSchema = z.output<typeof schema>;
 
 export const useEditActionsForm = ({
   actions,
@@ -16,7 +17,7 @@ export const useEditActionsForm = ({
   actions: Scene["actions"];
   onSave: (payload: { actions: Scene["actions"] }) => void;
 }) => {
-  const form = useForm<EditActionsSchema>({
+  const form = useForm<EditActionsSchemaInput, unknown, EditActionsSchema>({
     resolver: zodResolver(schema),
     values: { actions },
   });
@@ -31,13 +32,7 @@ export const useEditActionsForm = ({
     onSubmit: (values) => onSave({ actions: values.actions }),
   });
 
-  return {
-    form,
-    fields,
-    append,
-    remove,
-    update,
-  };
+  return { form, fields, append, remove, update };
 };
 
 export type EditActionsForm = UseFormReturn<EditActionsSchema>;

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -1,36 +1,13 @@
 import { useFieldArray, useForm, UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Action, Scene } from "@/lib/storage/domain";
-import { match } from "ts-pattern";
+import { Scene } from "@/lib/storage/domain";
 import z from "zod";
 import { useAutoSubmitForm } from "@/hooks/use-auto-submit-form";
-
-const actionBase = z.object({
-  key: z.nanoid(),
-  text: z.string({ message: "Text is required" }),
-  targets: z.array(z.object({ sceneKey: z.nanoid(), probability: z.number() })),
-});
-
-const actionSchema = z.discriminatedUnion("showCondition", [
-  actionBase.extend({ showCondition: z.literal("always") }),
-  actionBase.extend({
-    showCondition: z.literal("when-user-did-visit"),
-    targetSceneKey: z.nanoid(),
-  }),
-  actionBase.extend({
-    showCondition: z.literal("when-user-did-not-visit"),
-    targetSceneKey: z.nanoid(),
-  }),
-  actionBase.extend({
-    showCondition: z.literal("character-attribute"),
-  }),
-]);
+import { actionSchema } from "@/lib/action-schema";
 
 export type ActionSchema = z.infer<typeof actionSchema>;
 
-const schema = z.object({
-  actions: z.array(actionSchema),
-});
+const schema = z.object({ actions: z.array(actionSchema) });
 
 export type EditActionsSchema = z.infer<typeof schema>;
 
@@ -41,57 +18,9 @@ export const useEditActionsForm = ({
   actions: Scene["actions"];
   onSave: (payload: { actions: Scene["actions"] }) => void;
 }) => {
-  const adaptDomainAction = (action: Action) => {
-    return match<Action, ActionSchema>(action)
-      .with({ type: "conditional" }, (a) => ({
-        key: a.key,
-        showCondition:
-          a.condition.type === "user-did-visit"
-            ? "when-user-did-visit"
-            : "when-user-did-not-visit",
-        text: a.text,
-        targets: a.targets,
-        targetSceneKey: a.condition.sceneKey,
-      }))
-      .with({ type: "simple" }, (a) => ({
-        key: a.key,
-        showCondition: "always",
-        text: a.text,
-        targets: a.targets,
-      }))
-      .exhaustive();
-  };
-
-  const adaptFormAction = (formAction: ActionSchema) => {
-    return match<ActionSchema, Action>(formAction)
-      .with({ showCondition: "always" }, (a) => ({
-        key: a.key,
-        type: "simple",
-        text: a.text,
-        targets: a.targets,
-      }))
-      .with({ showCondition: "when-user-did-visit" }, (a) => ({
-        key: a.key,
-        type: "conditional",
-        text: a.text,
-        targets: a.targets,
-        condition: { type: "user-did-visit", sceneKey: a.targetSceneKey },
-      }))
-      .with({ showCondition: "when-user-did-not-visit" }, (a) => ({
-        key: a.key,
-        type: "conditional",
-        text: a.text,
-        targets: a.targets,
-        condition: { type: "user-did-not-visit", sceneKey: a.targetSceneKey },
-      }))
-      .exhaustive();
-  };
-
   const form = useForm<EditActionsSchema>({
     resolver: zodResolver(schema),
-    values: {
-      actions: actions.map(adaptDomainAction),
-    },
+    values: { actions },
   });
 
   const { fields, append, remove, update } = useFieldArray({
@@ -101,10 +30,7 @@ export const useEditActionsForm = ({
 
   useAutoSubmitForm({
     form,
-    onSubmit: (values) =>
-      onSave({
-        actions: values.actions.map(adaptFormAction),
-      }),
+    onSubmit: (values) => onSave({ actions: values.actions }),
   });
 
   return {
@@ -113,8 +39,6 @@ export const useEditActionsForm = ({
     append,
     remove,
     update,
-    adaptDomainAction,
-    adaptFormAction,
   };
 };
 

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -21,6 +21,9 @@ const actionSchema = z.discriminatedUnion("showCondition", [
     showCondition: z.literal("when-user-did-not-visit"),
     targetSceneKey: z.nanoid(),
   }),
+  actionBase.extend({
+    showCondition: z.literal("character-attribute"),
+  }),
 ]);
 
 export type ActionSchema = z.infer<typeof actionSchema>;

--- a/client/src/design-system/components/number-input.tsx
+++ b/client/src/design-system/components/number-input.tsx
@@ -1,0 +1,47 @@
+import { MaskitoOptions } from "@maskito/core";
+import { Input } from "../primitives/input";
+import { useMaskito } from "@maskito/react";
+import { RefCallback } from "react";
+
+const mask = {
+  mask: /^[0-9]*$/, // Only numbers
+} satisfies MaskitoOptions;
+
+/**
+ * A uncontrolled number input
+ * For now it doesn't handle :
+ * - Negative numbers
+ * - Floats
+ * - Setting the value via ⌃⌄
+ * Feel free to add these features
+ */
+export const NumberInput = ({
+  ref,
+  onChange,
+  className,
+  defaultValue,
+}: {
+  ref?: RefCallback<HTMLInputElement>;
+  onChange: (v: number | undefined) => void;
+  className?: string;
+  defaultValue: number;
+}) => {
+  const inputRef = useMaskito({ options: mask });
+
+  return (
+    <Input
+      ref={(node) => {
+        inputRef(node);
+        if (typeof ref === "function") ref(node);
+      }}
+      // Maskito strongly suggests using onInput rather than onChange => https://maskito.dev/frameworks/react
+      onInput={(e) => {
+        const stringValue = e.currentTarget.value;
+        if (stringValue !== "") onChange?.(parseInt(stringValue));
+        else onChange?.(undefined);
+      }}
+      defaultValue={defaultValue}
+      className={className}
+    />
+  );
+};

--- a/client/src/design-system/components/toolbar.tsx
+++ b/client/src/design-system/components/toolbar.tsx
@@ -15,7 +15,7 @@ export const Toolbar = ({
   return (
     <div
       className={cn(
-        "ring-border z-40 rounded-xl bg-white/95 p-3 shadow-sm ring-1",
+        "ring-border z-40 rounded-xl bg-white/98 p-3 shadow-sm ring-1",
         className,
       )}
     >

--- a/client/src/design-system/primitives/input.tsx
+++ b/client/src/design-system/primitives/input.tsx
@@ -1,8 +1,7 @@
+import { cn } from "@/lib/style";
 import * as React from "react";
 
-import { cn } from "@/lib/style";
-
-// Modified to reduce lighten the color of the ring
+// Modified to lighten ring color
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -10,9 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/10 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/10 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 file:text-foreground placeholder:text-muted-foreground h-8 w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm",
         className,
       )}
       {...props}

--- a/client/src/design-system/primitives/select.tsx
+++ b/client/src/design-system/primitives/select.tsx
@@ -1,7 +1,9 @@
-import * as React from "react";
-import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+"use client";
 
+import * as React from "react";
+import { Select as SelectPrimitive } from "radix-ui";
+
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react";
 import { cn } from "@/lib/style";
 
 function Select({
@@ -11,9 +13,16 @@ function Select({
 }
 
 function SelectGroup({
+  className,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  );
 }
 
 function SelectValue({
@@ -35,14 +44,14 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 bgize=default]:h-9 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 flex w-fit items-center justify-between gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -51,28 +60,31 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "popper",
+  position = "item-aligned",
+  align = "center",
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg shadow-md ring-1 duration-100 data-[align-trigger=true]:animate-none",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,
         )}
         position={position}
+        align={align}
         {...props}
       >
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
+          data-position={position}
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1",
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && "",
           )}
         >
           {children}
@@ -90,7 +102,7 @@ function SelectLabel({
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn("text-muted-foreground px-1.5 py-1 text-xs", className)}
       {...props}
     />
   );
@@ -105,14 +117,14 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="pointer-events-none" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -141,12 +153,12 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
-      <ChevronUpIcon className="size-4" />
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -159,12 +171,12 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
       className={cn(
-        "flex cursor-default items-center justify-center py-1",
+        "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
-      <ChevronDownIcon className="size-4" />
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownButton>
   );
 }

--- a/client/src/domains/builder/builder-service.ts
+++ b/client/src/domains/builder/builder-service.ts
@@ -399,20 +399,23 @@ export const _getBuilderService = ({
             type: "builder",
           });
 
+          let oldCharacterAttrToNew: Record<string, string> = {};
+          if (importData.characterConfig)
+            oldCharacterAttrToNew = await importService.createCharacterConfig({
+              newStoryKey: storyResult.data.key,
+              characterConfig: importData.characterConfig,
+            });
+
           const oldScenesToNew = await importService.createScenes({
             story: importData,
             newStoryKey: storyResult.data.key,
+            oldCharacterAttrToNew,
           });
 
           if (importData.theme)
             await importService.createTheme({
               newStoryKey: storyResult.data.key,
               theme: importData.theme,
-            });
-          if (importData.characterConfig)
-            await importService.createCharacterConfig({
-              newStoryKey: storyResult.data.key,
-              characterConfig: importData.characterConfig,
             });
 
           if (importData.wiki)

--- a/client/src/domains/game/library-service.ts
+++ b/client/src/domains/game/library-service.ts
@@ -110,20 +110,23 @@ export const _getLibraryService = ({
             type: "imported",
           });
 
+          let oldCharacterAttrToNew: Record<string, string> = {};
+          if (importData.characterConfig)
+            oldCharacterAttrToNew = await importService.createCharacterConfig({
+              newStoryKey: story.data.key,
+              characterConfig: importData.characterConfig,
+            });
+
           const oldScenesToNew = await importService.createScenes({
             story: importData,
             newStoryKey: story.data.key,
+            oldCharacterAttrToNew,
           });
 
           if (importData.theme)
             await importService.createTheme({
               newStoryKey: story.data.key,
               theme: importData.theme,
-            });
-          if (importData.characterConfig)
-            await importService.createCharacterConfig({
-              newStoryKey: story.data.key,
-              characterConfig: importData.characterConfig,
             });
 
           if (importData.wiki)

--- a/client/src/game/hooks/use-action-visibility.ts
+++ b/client/src/game/hooks/use-action-visibility.ts
@@ -19,5 +19,9 @@ export const useActionVisibility = ({
       { type: "user-did-not-visit" },
       (condition) => !progress.history.includes(condition.sceneKey),
     )
+    .with({ type: "character-attribute" }, () => {
+      // TODO: handle this (https://github.com/JeremieLeymarie/story-builder/issues/458)
+      return true;
+    })
     .exhaustive();
 };

--- a/client/src/hooks/use-auto-submit-form.ts
+++ b/client/src/hooks/use-auto-submit-form.ts
@@ -16,7 +16,7 @@ export const useAutoSubmitForm = <TFormSchema extends FieldValues>({
 
   const debouncer = useDebouncer(
     () => {
-      form.handleSubmit(onSubmit)();
+      form.handleSubmit(onSubmit, (invalid) => console.error(invalid))();
     },
     { wait: debounceAfter },
     () => {}, // Never re-render when internal debouncer state changes

--- a/client/src/lib/action-schema.ts
+++ b/client/src/lib/action-schema.ts
@@ -18,15 +18,26 @@ const baseActionSchema = z.object({
     ),
 });
 
+const sceneVisitCondition = z.object({
+  type: z.enum(["user-did-visit", "user-did-not-visit"]),
+  sceneKey: z.nanoid(),
+});
+
+const characterAttributeCondition = z.object({
+  type: z.literal("character-attribute"),
+  attributeKey: z.nanoid(),
+  comparator: z.union([z.literal("lower-than"), z.literal("greater-than")]),
+});
+
 export const actionSchema = z.discriminatedUnion("type", [
   baseActionSchema.extend({
     type: z.literal("simple"),
   }),
   baseActionSchema.extend({
     type: z.literal("conditional"),
-    condition: z.object({
-      type: z.enum(["user-did-visit", "user-did-not-visit"]),
-      sceneKey: z.nanoid(),
-    }),
+    condition: z.discriminatedUnion("type", [
+      sceneVisitCondition,
+      characterAttributeCondition,
+    ]),
   }),
 ]);

--- a/client/src/lib/action-schema.ts
+++ b/client/src/lib/action-schema.ts
@@ -7,10 +7,14 @@ const baseActionSchema = z.object({
     .array(z.object({ sceneKey: z.nanoid(), probability: z.number() }))
     .refine(
       (values) => {
+        if (values.length === 0) return true;
+
         const totalProbabilities = values.reduce(
           (acc, v) => acc + v.probability,
           0,
         );
+
+        console.log({ totalProbabilities });
 
         return totalProbabilities > 0;
       },

--- a/client/src/lib/action-schema.ts
+++ b/client/src/lib/action-schema.ts
@@ -14,8 +14,6 @@ const baseActionSchema = z.object({
           0,
         );
 
-        console.log({ totalProbabilities });
-
         return totalProbabilities > 0;
       },
       { error: "All targets of an action must add up to at least 1%" },

--- a/client/src/lib/action-schema.ts
+++ b/client/src/lib/action-schema.ts
@@ -27,6 +27,7 @@ const characterAttributeCondition = z.object({
   type: z.literal("character-attribute"),
   attributeKey: z.nanoid(),
   comparator: z.union([z.literal("lower-than"), z.literal("greater-than")]),
+  value: z.int(),
 });
 
 export const actionSchema = z.discriminatedUnion("type", [

--- a/client/src/lib/http-client/adapters.ts
+++ b/client/src/lib/http-client/adapters.ts
@@ -12,7 +12,7 @@ import { match } from "ts-pattern";
 
 type APISceneAction =
   | components["schemas"]["SimpleAction"]
-  | components["schemas"]["ConditionalAction"];
+  | components["schemas"]["ConditionalAction-Output"];
 
 const _toAPIDate = (date: Date) => dayjs(date).format("YYYY-MM-DD[T]hh:mm:ss");
 

--- a/client/src/lib/http-client/schema.d.ts
+++ b/client/src/lib/http-client/schema.d.ts
@@ -122,18 +122,42 @@ export interface components {
             /** Y */
             y: number;
         };
-        /** Condition */
-        Condition: {
+        /** CharacterAttributeCondition */
+        CharacterAttributeCondition: {
             /**
              * Type
+             * @constant
              * @enum {string}
              */
-            type: "user-did-visit" | "user-did-not-visit";
-            /** Scenekey */
-            sceneKey: string;
+            type: "character-attribute";
+            /** Attributekey */
+            attributeKey: string;
+            /**
+             * Comparator
+             * @enum {string}
+             */
+            comparator: "lower-than" | "greater-than";
+            /** Value */
+            value: number;
+        };
+        Condition: components["schemas"]["SceneVisitCondition"] | components["schemas"]["CharacterAttributeCondition"];
+        /** ConditionalAction */
+        "ConditionalAction-Input": {
+            /** Key */
+            key: string;
+            /** Text */
+            text: string;
+            /** Targets */
+            targets: components["schemas"]["ActionTarget"][];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "conditional";
+            condition: components["schemas"]["Condition"];
         };
         /** ConditionalAction */
-        ConditionalAction: {
+        "ConditionalAction-Output": {
             /** Key */
             key: string;
             /** Text */
@@ -258,7 +282,7 @@ export interface components {
                 [key: string]: components["schemas"]["JsonValue"];
             };
             /** Actions */
-            actions: (components["schemas"]["SimpleAction"] | components["schemas"]["ConditionalAction"])[];
+            actions: (components["schemas"]["SimpleAction"] | components["schemas"]["ConditionalAction-Input"])[];
             builderParams: components["schemas"]["BuilderParams"];
         };
         /** Scene */
@@ -274,8 +298,18 @@ export interface components {
                 [key: string]: components["schemas"]["JsonValue"];
             };
             /** Actions */
-            actions: (components["schemas"]["SimpleAction"] | components["schemas"]["ConditionalAction"])[];
+            actions: (components["schemas"]["SimpleAction"] | components["schemas"]["ConditionalAction-Output"])[];
             builderParams: components["schemas"]["BuilderParams"];
+        };
+        /** SceneVisitCondition */
+        SceneVisitCondition: {
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "user-did-visit" | "user-did-not-visit";
+            /** Scenekey */
+            sceneKey: string;
         };
         /** SimpleAction */
         SimpleAction: {

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -87,12 +87,20 @@ type SimpleAction = ActionBase & {
   type: "simple";
 };
 
+type SceneVisitCondition = {
+  type: "user-did-visit" | "user-did-not-visit";
+  sceneKey: string;
+};
+
+type CharacterAttributeCondition = {
+  type: "character-attribute";
+  attributeKey: string;
+  comparator: "lower-than" | "greater-than"; // Add more flavors?
+};
+
 type ConditionalAction = ActionBase & {
   type: "conditional";
-  condition: {
-    type: "user-did-visit" | "user-did-not-visit";
-    sceneKey: string;
-  };
+  condition: SceneVisitCondition | CharacterAttributeCondition;
 };
 
 export type Action = SimpleAction | ConditionalAction;

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -107,11 +107,6 @@ export const isSceneVisitCondition = (
   condition.type === "user-did-not-visit" ||
   condition.type === "user-did-visit";
 
-export const isCharacterAttributeCondition = (
-  condition: ActionCondition,
-): condition is CharacterAttributeCondition =>
-  condition.type === "character-attribute";
-
 export type ConditionalAction = ActionBase & {
   type: "conditional";
   condition: ActionCondition;

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -92,7 +92,7 @@ type SceneVisitCondition = {
   sceneKey: string;
 };
 
-type CharacterAttributeCondition = {
+export type CharacterAttributeCondition = {
   type: "character-attribute";
   attributeKey: string;
   comparator: "lower-than" | "greater-than"; // Add more flavors?

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -96,11 +96,25 @@ type CharacterAttributeCondition = {
   type: "character-attribute";
   attributeKey: string;
   comparator: "lower-than" | "greater-than"; // Add more flavors?
+  value: number;
 };
 
-type ConditionalAction = ActionBase & {
+type ActionCondition = SceneVisitCondition | CharacterAttributeCondition;
+
+export const isSceneVisitCondition = (
+  condition: ActionCondition,
+): condition is SceneVisitCondition =>
+  condition.type === "user-did-not-visit" ||
+  condition.type === "user-did-visit";
+
+export const isCharacterAttributeCondition = (
+  condition: ActionCondition,
+): condition is CharacterAttributeCondition =>
+  condition.type === "character-attribute";
+
+export type ConditionalAction = ActionBase & {
   type: "conditional";
-  condition: SceneVisitCondition | CharacterAttributeCondition;
+  condition: ActionCondition;
 };
 
 export type Action = SimpleAction | ConditionalAction;

--- a/client/src/services/common/__tests__/import-service.test.ts
+++ b/client/src/services/common/__tests__/import-service.test.ts
@@ -33,7 +33,6 @@ import {
 const STORY_KEY = nanoid();
 const SCENE_KEY_A = nanoid();
 const SCENE_KEY_B = nanoid();
-const SCENE_KEY_C = nanoid();
 
 const DEX_ATTRIBUTE = {
   key: nanoid(),
@@ -81,7 +80,8 @@ const BASIC_SCENE: ImportData["scenes"][number] = {
   },
 };
 
-const SCENE_WITH_SIMPLE_ACTION: ImportData["scenes"][number] = {
+// TODO: add probabilities
+const SCENE_WITH_ACTIONS: ImportData["scenes"][number] = {
   key: SCENE_KEY_B,
   storyKey: STORY_KEY,
   title: "Your first scene",
@@ -98,33 +98,35 @@ const SCENE_WITH_SIMPLE_ACTION: ImportData["scenes"][number] = {
         },
       ],
     },
-  ],
-  builderParams: {
-    position: {
-      x: 0,
-      y: 0,
-    },
-  },
-};
-
-const SCENE_WITH_CONDITIONAL_ACTIONS: ImportData["scenes"][number] = {
-  key: SCENE_KEY_C,
-  storyKey: BASIC_SCENE.key,
-  title: "Your first scene",
-  content: BASIC_SCENE_CONTENT,
-  actions: [
     {
       key: nanoid(),
       type: "conditional",
-      text: "conditional-action",
+      text: "conditional-action-visit",
       targets: [
         {
-          sceneKey: SCENE_WITH_SIMPLE_ACTION.key,
+          sceneKey: SCENE_KEY_A,
           probability: 100,
         },
       ],
       condition: { type: "user-did-visit", sceneKey: BASIC_SCENE.key },
     },
+    {
+      key: nanoid(),
+      type: "conditional",
+      text: "conditional-action-attribute",
+      targets: [
+        {
+          sceneKey: SCENE_KEY_A,
+          probability: 100,
+        },
+      ],
+      condition: {
+        type: "character-attribute",
+        attributeKey: DEX_ATTRIBUTE.key,
+        comparator: "lower-than",
+        value: 10,
+      },
+    },
   ],
   builderParams: {
     position: {
@@ -134,20 +136,16 @@ const SCENE_WITH_CONDITIONAL_ACTIONS: ImportData["scenes"][number] = {
   },
 };
 
-const importedScenes = [
-  BASIC_SCENE,
-  SCENE_WITH_SIMPLE_ACTION,
-  SCENE_WITH_CONDITIONAL_ACTIONS,
-];
+const IMPORTED_SCENES = [BASIC_SCENE, SCENE_WITH_ACTIONS];
 
-const theme = DEFAULT_STORY_THEME;
+const IMPORTED_THEME = DEFAULT_STORY_THEME;
 
-const importData = {
+const IMPORTED_DATA = {
   story: IMPORTED_STORY,
-  scenes: importedScenes,
+  scenes: IMPORTED_SCENES,
 } satisfies ImportData;
 
-const fileContent = JSON.stringify(importData);
+const fileContent = JSON.stringify(IMPORTED_DATA);
 
 describe("import-service", () => {
   let localRepository: MockLocalRepository;
@@ -200,7 +198,7 @@ describe("import-service", () => {
 
       expect(result).toStrictEqual({
         isOk: true,
-        data: importData,
+        data: IMPORTED_DATA,
       });
       expect(localRepository.createStory).not.toHaveBeenCalled();
     });
@@ -209,7 +207,7 @@ describe("import-service", () => {
   describe("createStory", () => {
     it("should create story (imported)", async () => {
       const result = await importService.createStory({
-        story: { story: importData.story, scenes: importData.scenes },
+        story: { story: IMPORTED_DATA.story, scenes: IMPORTED_DATA.scenes },
         type: "imported",
       });
 
@@ -237,8 +235,8 @@ describe("import-service", () => {
     it("should create story with anonymous author", async () => {
       const result = await importService.createStory({
         story: {
-          story: { ...importData.story, author: undefined },
-          scenes: importData.scenes,
+          story: { ...IMPORTED_DATA.story, author: undefined },
+          scenes: IMPORTED_DATA.scenes,
         },
         type: "imported",
       });
@@ -274,7 +272,7 @@ describe("import-service", () => {
       );
 
       const result = await importService.createStory({
-        story: { story: importData.story, scenes: importData.scenes },
+        story: { story: IMPORTED_DATA.story, scenes: IMPORTED_DATA.scenes },
         type: "builder",
       });
 
@@ -302,79 +300,48 @@ describe("import-service", () => {
 
   describe("createScenes", () => {
     it("should produce correct bulk update payload", () => {
-      const storyFromImport: ImportData = {
-        story: IMPORTED_STORY,
-        scenes: [
-          {
-            key: "old-source-scene",
-            storyKey: IMPORTED_STORY.key,
-            title: "Your first scene",
-            content: BASIC_SCENE_CONTENT,
-            actions: [
-              {
-                key: "action-key-a",
-                text: "An action that leads to a scene",
-                targets: [
-                  {
-                    sceneKey: "old-dest-scene",
-                    probability: 100,
-                  },
-                ],
-                type: "simple",
-              },
-              {
-                key: "action-key-b",
-                text: "An action that leads to another scene",
-                targets: [],
-                type: "simple",
-              },
-            ],
-            builderParams: {
-              position: {
-                x: 0,
-                y: 0,
-              },
-            },
-          },
-          {
-            key: "old-dest-scene",
-            storyKey: IMPORTED_STORY.key,
-            title: "title",
-            content: BASIC_SCENE_CONTENT,
-            actions: [],
-            builderParams: {
-              position: {
-                x: 0,
-                y: 0,
-              },
-            },
-          },
-        ],
-      };
-
       const payload = _makeBulkSceneUpdatePayload({
         oldScenesToNewScenes: {
-          "old-dest-scene": "new-dest-scene",
-          "old-source-scene": "new-source-scene",
+          [BASIC_SCENE.key]: "new-basic-scene",
+          [SCENE_WITH_ACTIONS.key]: "new-scene-with-actions",
         },
-        storyFromImport,
+        storyFromImport: IMPORTED_DATA,
+        oldCharacterAttrToNew: { [DEX_ATTRIBUTE.key]: "new-dex-key" },
       });
+
+      // BASIC_SCENE is skipped because it doesn't need to be updated (no actions)
 
       expect(payload).toStrictEqual([
         {
-          key: "new-source-scene",
+          key: "new-scene-with-actions",
           actions: [
             {
               key: expect.any(String),
               type: "simple",
               text: "An action that leads to a scene",
-              targets: [{ sceneKey: "new-dest-scene", probability: 100 }],
+              targets: [{ sceneKey: "new-basic-scene", probability: 100 }],
             },
             {
               key: expect.any(String),
-              type: "simple",
-              text: "An action that leads to another scene",
-              targets: [],
+              type: "conditional",
+              text: "conditional-action-visit",
+              targets: [{ sceneKey: "new-basic-scene", probability: 100 }],
+              condition: {
+                type: "user-did-visit",
+                sceneKey: "new-basic-scene",
+              },
+            },
+            {
+              key: expect.any(String),
+              type: "conditional",
+              text: "conditional-action-attribute",
+              targets: [{ sceneKey: "new-basic-scene", probability: 100 }],
+              condition: {
+                type: "character-attribute",
+                attributeKey: "new-dex-key",
+                comparator: "lower-than",
+                value: 10,
+              },
             },
           ],
         },
@@ -392,8 +359,9 @@ describe("import-service", () => {
       });
 
       const result = await importService.createScenes({
-        story: { story: importData.story, scenes: importData.scenes },
+        story: { story: IMPORTED_DATA.story, scenes: IMPORTED_DATA.scenes },
         newStoryKey: "new-story-key",
+        oldCharacterAttrToNew: { [DEX_ATTRIBUTE.key]: "new-dex-key" },
       });
 
       // Scene is created with new story key & no actions at first
@@ -416,9 +384,8 @@ describe("import-service", () => {
         "new-scene-key-2",
       );
       expect(result).toStrictEqual({
-        [importData.scenes[0]!.key]: "new-scene-key-1",
-        [importData.scenes[1]!.key]: "new-scene-key-2",
-        [importData.scenes[2]!.key]: "new-scene-key-3",
+        [IMPORTED_DATA.scenes[0]!.key]: "new-scene-key-1",
+        [IMPORTED_DATA.scenes[1]!.key]: "new-scene-key-2",
       });
     });
   });
@@ -427,26 +394,32 @@ describe("import-service", () => {
     it("should import theme with new story key", async () => {
       await importService.createTheme({
         newStoryKey: "new-story-key",
-        theme,
+        theme: IMPORTED_THEME,
       });
 
       expect(themeRepository.create).toHaveBeenCalledWith({
         storyKey: "new-story-key",
-        theme,
+        theme: IMPORTED_THEME,
       });
     });
   });
 
   describe("createCharacterConfig", () => {
     it("should import characterConfig with new story key", async () => {
+      characterRepository.create = vi.fn(async (cc) => {
+        expect(cc.storyKey).toStrictEqual("new-story-key");
+        expect(Object.keys(cc.attributes)).toHaveLength(1);
+
+        const [key, attr] = Object.entries(cc.attributes)[0]!;
+        expect(key).not.toStrictEqual(DEX_ATTRIBUTE.key);
+        expect(attr.key).not.toStrictEqual(DEX_ATTRIBUTE.key);
+
+        return Promise.resolve("new-key");
+      });
+
       await importService.createCharacterConfig({
         newStoryKey: "new-story-key",
         characterConfig: CHARACTER_CONFIG,
-      });
-
-      expect(characterRepository.create).toHaveBeenCalledWith({
-        storyKey: "new-story-key",
-        attributes: CHARACTER_CONFIG.attributes,
       });
     });
   });

--- a/client/src/services/common/import-service.ts
+++ b/client/src/services/common/import-service.ts
@@ -1,8 +1,15 @@
-import { BuilderStory, LibraryStory, Story, Wiki } from "@/lib/storage/domain";
+import {
+  BuilderStory,
+  ConditionalAction,
+  LibraryStory,
+  Scene,
+  Story,
+  Wiki,
+} from "@/lib/storage/domain";
 import { getLocalRepository, LocalRepositoryPort } from "@/repositories";
 import { WithoutKey } from "@/types";
 import z from "zod";
-import { produce } from "immer";
+import { produce, WritableDraft } from "immer";
 import {
   CharacterConfigFromImport,
   ImportData,
@@ -23,6 +30,7 @@ import {
   CharacterRepositoryPort,
   getDexieCharacterRepository,
 } from "@/domains/builder/character-repository";
+import { match, P } from "ts-pattern";
 
 export const ANONYMOUS_AUTHOR = {
   key: "ANONYMOUS_AUTHOR_KEY",
@@ -59,6 +67,7 @@ export type ImportServicePort = {
   createScenes: (props: {
     story: ImportData;
     newStoryKey: string;
+    oldCharacterAttrToNew: Record<string, string>;
   }) => Promise<Record<string, string>>;
   createTheme: (props: {
     theme: ThemeFromImport;
@@ -67,7 +76,7 @@ export type ImportServicePort = {
   createCharacterConfig: (props: {
     characterConfig: CharacterConfigFromImport;
     newStoryKey: string;
-  }) => Promise<void>;
+  }) => Promise<Record<string, string>>;
   createWiki: (props: {
     wikiData: WikiFromImport;
     type: Wiki["type"];
@@ -76,12 +85,49 @@ export type ImportServicePort = {
   }) => Promise<void>;
 };
 
+// We should implement some kind of context instead of passing everything every time
+const _mutateConditionAction = ({
+  action,
+  scene,
+  oldScenesToNewScenes,
+  oldCharacterAttrToNew,
+}: {
+  action: WritableDraft<ConditionalAction>;
+  scene: Scene;
+  oldScenesToNewScenes: Record<string, string>;
+  oldCharacterAttrToNew: Record<string, string>;
+}) => {
+  match(action.condition)
+    .with(
+      { type: P.union("user-did-not-visit", "user-did-visit") },
+      (condition) => {
+        const newTargetSceneKey = oldScenesToNewScenes[condition.sceneKey];
+        if (!newTargetSceneKey)
+          throw new Error(
+            `sceneKey not found in old scene to new scenes mapping, for scene [${scene.title}] and action [${action.text}]`,
+          );
+        condition.sceneKey = newTargetSceneKey;
+      },
+    )
+    .with({ type: "character-attribute" }, (condition) => {
+      const newAttrKey = oldCharacterAttrToNew[condition.attributeKey];
+      if (!newAttrKey)
+        throw new Error(
+          `attributeKey not found in old character attributes to new attributes mapping, for character attribute [newAttrKey]`,
+        );
+      condition.attributeKey = newAttrKey;
+    })
+    .exhaustive();
+};
+
 export const _makeBulkSceneUpdatePayload = ({
   storyFromImport,
   oldScenesToNewScenes,
+  oldCharacterAttrToNew,
 }: {
   storyFromImport: ImportData;
   oldScenesToNewScenes: Record<string, string>;
+  oldCharacterAttrToNew: Record<string, string>;
 }) => {
   const scenesByKey = storyFromImport.scenes.reduce(
     (acc, scene) => ({
@@ -114,15 +160,13 @@ export const _makeBulkSceneUpdatePayload = ({
               sceneKey: newSceneKey,
             };
           });
-          if (draft.type === "conditional") {
-            const newTargetSceneKey =
-              oldScenesToNewScenes[draft.condition.sceneKey];
-            if (!newTargetSceneKey)
-              throw new Error(
-                `sceneKey not found in old scene to new scenes mapping, for scene [${scene.title}] and action [${action.text}]`,
-              ); // Should we throw here or should gracefully fallback on a simple action?
-            draft.condition.sceneKey = newTargetSceneKey;
-          }
+          if (draft.type === "conditional")
+            _mutateConditionAction({
+              action: draft,
+              scene,
+              oldScenesToNewScenes,
+              oldCharacterAttrToNew,
+            });
         }),
       );
 
@@ -313,7 +357,11 @@ export const _getImportService = ({
       return { data: story };
     },
 
-    createScenes: async ({ story: storyFromImport, newStoryKey }) => {
+    createScenes: async ({
+      story: storyFromImport,
+      newStoryKey,
+      oldCharacterAttrToNew,
+    }) => {
       const oldScenesToNewScenes: Record<string, string> = {};
 
       // Create scenes without actions
@@ -332,6 +380,7 @@ export const _getImportService = ({
         _makeBulkSceneUpdatePayload({
           storyFromImport,
           oldScenesToNewScenes,
+          oldCharacterAttrToNew,
         }),
       );
 
@@ -353,12 +402,23 @@ export const _getImportService = ({
     },
 
     createCharacterConfig: async ({ newStoryKey, characterConfig }) => {
+      const oldCharacterAttrToNew: Record<string, string> = Object.fromEntries(
+        Object.keys(characterConfig.attributes).map((key) => [key, nanoid()]),
+      );
+      const attributes = Object.entries(characterConfig.attributes).reduce(
+        (acc, [key, attr]) => {
+          const newKey = oldCharacterAttrToNew[key]!;
+          return { ...acc, [newKey]: { ...attr, key: newKey } };
+        },
+        {},
+      );
+
       await characterRepository.create({
         storyKey: newStoryKey,
-        attributes: characterConfig.attributes,
+        attributes,
       });
 
-      // TODO: update conditional actions when implemented
+      return oldCharacterAttrToNew;
     },
 
     createWiki: async ({ wikiData, type, oldScenesToNew, newStoryKey }) => {

--- a/server/app/domains/synchronization/repositories/adapters.py
+++ b/server/app/domains/synchronization/repositories/adapters.py
@@ -1,5 +1,7 @@
 from domains.synchronization.type_defs import (
-    SyncActionCondition,
+    SyncActionCharacterAttributeCondition,
+    SyncActionSceneVisitCondition,
+    SyncCondition,
     SyncActionTarget,
     SyncConditionalAction,
     SyncSimpleAction,
@@ -12,7 +14,9 @@ from domains.synchronization.type_defs import (
     SynchronizationStoryProgress,
 )
 from utils.mongo.base_repository import (
+    MongoActionCharacterAttributeCondition,
     MongoActionCondition,
+    MongoActionSceneVisitCondition,
     MongoActionTarget,
     MongoBuilderParams,
     MongoBuilderPosition,
@@ -37,6 +41,13 @@ def make_mongo_builder_params(
         position=MongoBuilderPosition(x=domain.position.x, y=domain.position.y)
     )
 
+def make_mongo_action_condition(domain: SyncCondition) -> MongoActionCondition:
+    if isinstance(domain, SyncActionSceneVisitCondition):
+        return MongoActionSceneVisitCondition(type=domain.type, sceneKey=domain.scene_key)
+    elif isinstance(domain, SyncActionCharacterAttributeCondition):
+        return MongoActionCharacterAttributeCondition(type=domain.type, attributeKey=domain.attribute_key, comparator=domain.comparator, value=domain.value)
+    else:
+        assert_never()
 
 def make_mongo_scene_action(domain: SynchronizationSceneAction) -> MongoSceneAction:
     if isinstance(domain, SyncSimpleAction):
@@ -62,9 +73,7 @@ def make_mongo_scene_action(domain: SynchronizationSceneAction) -> MongoSceneAct
                 )
                 for target in domain.targets
             ],
-            condition=MongoActionCondition(
-                type=domain.condition.type, sceneKey=domain.condition.scene_key
-            ),
+            condition=make_mongo_action_condition(domain.condition)
         )
     assert_never()
 
@@ -179,6 +188,15 @@ def make_synchronization_author(
     )
 
 
+def make_synchronization_condition(condition: MongoActionCondition) -> SyncCondition:
+    if condition["type"] == "user-did-not-visit" or condition["type"] == "user-did-visit" :
+        return SyncActionSceneVisitCondition(type=condition["type"], scene_key=condition["sceneKey"])
+    elif condition["type"] == "character-attribute":
+        return SyncActionCharacterAttributeCondition(type=condition["type"], attribute_key=condition["attributeKey"], comparator=condition["comparator"], value=condition["value"])
+    else:
+        assert_never()
+
+
 def make_synchronization_action(action: MongoSceneAction) -> SynchronizationSceneAction:
     if action["type"] == "simple":
         return SyncSimpleAction(
@@ -203,10 +221,7 @@ def make_synchronization_action(action: MongoSceneAction) -> SynchronizationScen
                 )
                 for target in action["targets"]
             ],
-            condition=SyncActionCondition(
-                type=action["condition"]["type"],
-                scene_key=action["condition"]["sceneKey"],
-            ),
+            condition=make_synchronization_condition(condition=action["condition"])
         )
     assert_never()
 

--- a/server/app/domains/synchronization/type_defs.py
+++ b/server/app/domains/synchronization/type_defs.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Literal, Union
+from typing import Any, Literal
 from pydantic import BaseModel
 
 from utils.type_defs import StoryGenre, StoryType
@@ -21,17 +21,25 @@ class SyncSimpleAction(_ActionBase):
     type: Literal["simple"]
 
 
-class SyncActionCondition(BaseModel):
+class SyncActionSceneVisitCondition(BaseModel):
     type: Literal["user-did-visit", "user-did-not-visit"]
     scene_key: str
 
 
+class SyncActionCharacterAttributeCondition(BaseModel):
+    type : Literal["character-attribute"]
+    attribute_key: str
+    comparator : Literal["lower-than", "greater-than"]
+    value: int
+
+type SyncCondition = SyncActionSceneVisitCondition | SyncActionCharacterAttributeCondition
+
 class SyncConditionalAction(_ActionBase):
     type: Literal["conditional"]
-    condition: SyncActionCondition
+    condition: SyncCondition
 
 
-SynchronizationSceneAction = Union[SyncSimpleAction, SyncConditionalAction]
+type SynchronizationSceneAction = SyncSimpleAction |  SyncConditionalAction
 
 
 class SynchronizationBuilderPosition(BaseModel):

--- a/server/app/endpoints/synchronization/type_defs.py
+++ b/server/app/endpoints/synchronization/type_defs.py
@@ -3,8 +3,10 @@ from typing import Annotated, Literal, Self, Union, assert_never
 from pydantic import Field, JsonValue
 
 from domains.synchronization.type_defs import (
-    SyncActionCondition,
+    SyncActionCharacterAttributeCondition,
+    SyncActionSceneVisitCondition,
     SyncActionTarget,
+    SyncCondition,
     SyncConditionalAction,
     SyncSimpleAction,
     SynchronizationBuilderParams,
@@ -34,10 +36,17 @@ class SimpleAction(_ActionBase):
     type: Literal["simple"]
 
 
-class Condition(BaseAPIModel):
+class SceneVisitCondition(BaseAPIModel):
     type: Literal["user-did-visit", "user-did-not-visit"]
     scene_key: str
 
+class CharacterAttributeCondition(BaseAPIModel):
+    type : Literal["character-attribute"]
+    attribute_key: str
+    comparator : Literal["lower-than", "greater-than"]
+    value: int
+
+type Condition = SceneVisitCondition | CharacterAttributeCondition
 
 class ConditionalAction(_ActionBase):
     type: Literal["conditional"]
@@ -63,6 +72,15 @@ class Scene(BaseAPIModel):
     content: dict[str, JsonValue]
     actions: list[Action]
     builder_params: BuilderParams
+
+    @classmethod
+    def _make_condition_from_domain(cls, domain_cond: SyncCondition) -> Condition:
+        if isinstance(domain_cond,SyncActionSceneVisitCondition ):
+            return SceneVisitCondition(type=domain_cond.type,scene_key=domain_cond.scene_key)
+        elif isinstance(domain_cond, SyncActionCharacterAttributeCondition):
+            return CharacterAttributeCondition(type=domain_cond.type, attribute_key=domain_cond.attribute_key, comparator=domain_cond.comparator, value=domain_cond.value )
+        else:
+            assert_never()
 
     @classmethod
     def _make_action_from_domain(
@@ -91,10 +109,7 @@ class Scene(BaseAPIModel):
                     for target in domain_action.targets
                 ],
                 type="conditional",
-                condition=Condition(
-                    type=domain_action.condition.type,
-                    scene_key=domain_action.condition.scene_key,
-                ),
+                condition=cls._make_condition_from_domain(domain_action.condition),
             )
         assert_never()
 
@@ -113,6 +128,14 @@ class Scene(BaseAPIModel):
                 )
             ),
         )
+
+    def _condition_to_domain(self, condition: Condition) -> SyncCondition:
+        if isinstance(condition, SceneVisitCondition):
+            return SyncActionSceneVisitCondition(type=condition.type, scene_key=condition.scene_key)
+        elif isinstance(condition, CharacterAttributeCondition):
+            return SyncActionCharacterAttributeCondition(type=condition.type, attribute_key=condition.attribute_key, comparator=condition.comparator, value=condition.value)
+        else:
+            assert_never()
 
     def _action_to_domain(self, action: Action) -> SynchronizationSceneAction:
         if isinstance(action, SimpleAction):
@@ -138,9 +161,7 @@ class Scene(BaseAPIModel):
                     for target in action.targets
                 ],
                 type="conditional",
-                condition=SyncActionCondition(
-                    type=action.condition.type, scene_key=action.condition.scene_key
-                ),
+                condition=self._condition_to_domain(action.condition),
             )
         assert_never()
 

--- a/server/app/tests/test_synchronization_load.py
+++ b/server/app/tests/test_synchronization_load.py
@@ -17,8 +17,8 @@ from utils.type_defs import StoryGenre, StoryType
 URL = "/api/load"
 
 
-def test_unauthorized(api_test_infra_no_auth) -> None:
-    response = api_test_infra_no_auth.client.get(URL)
+def test_unauthorized(api_test_infra_no_token) -> None:
+    response = api_test_infra_no_token.client.get(URL)
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.json() == {"detail": "Invalid token"}

--- a/server/app/tests/test_synchronization_save_stories.py
+++ b/server/app/tests/test_synchronization_save_stories.py
@@ -17,8 +17,8 @@ from utils.mongo.base_repository import (
 URL = "/api/save/stories"
 
 
-def test_unauthorized(api_test_infra_no_auth) -> None:
-    response = api_test_infra_no_auth.client.put(URL)
+def test_unauthorized(api_test_infra_no_token) -> None:
+    response = api_test_infra_no_token.client.put(URL)
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.json() == {"detail": "Invalid token"}

--- a/server/app/tests/test_synchronization_story_progress.py
+++ b/server/app/tests/test_synchronization_story_progress.py
@@ -8,8 +8,8 @@ from utils.mongo.base_repository import MongoStoryProgress
 URL = "/api/save/progresses"
 
 
-def test_unauthorized(api_test_infra_no_auth) -> None:
-    response = api_test_infra_no_auth.client.put(URL)
+def test_unauthorized(api_test_infra_no_token) -> None:
+    response = api_test_infra_no_token.client.put(URL)
 
     assert response.status_code == HTTPStatus.UNAUTHORIZED
     assert response.json() == {"detail": "Invalid token"}

--- a/server/app/utils/mongo/base_repository.py
+++ b/server/app/utils/mongo/base_repository.py
@@ -35,10 +35,17 @@ class MongoSimpleAction(_ActionBase):
     type: Literal["simple"]
 
 
-class MongoActionCondition(TypedDict):
+class MongoActionSceneVisitCondition(TypedDict):
     type: Literal["user-did-visit", "user-did-not-visit"]
     sceneKey: str
 
+class MongoActionCharacterAttributeCondition(TypedDict):
+    type : Literal["character-attribute"]
+    attributeKey: str
+    comparator : Literal["lower-than", "greater-than"]
+    value: int
+
+type MongoActionCondition = MongoActionSceneVisitCondition | MongoActionCharacterAttributeCondition
 
 class MongoConditionalAction(_ActionBase):
     type: Literal["conditional"]


### PR DESCRIPTION
Gestion des actions conditionnelles sur les attributs de personnage
Ça va avec une réécriture quasi totale du form des actions, pour (idéalement) simplifier : 
- Avant : on venait adapter le type du domaine dans vers format spécifique pour le formulaire et on le re-transformait dans l'autre sens. Le but était de simplifier la gestion du form, du rendering, mais ça complexifiait l'entrée dans le code, et ça voulait dire qu'à chaque ajout de type de condition il fallait se repencher sur le format défini spécifiquement pour ce form + il restait de la complexité dans le rendering dans tous les cas
- Maintenant : On prend directement le format du domaine, et c'est le rendering qui se charge de la complexité. J'ai l'impression qu'avec les match pattern ça reste pas trop compliqué. Le plus relou c'est dans use-condition-change, où on bypass RHF pour gérer nous-même les updates de valeurs du form
Je suis pas encore complètement convaincu que c'est mieux, en tout cas c'est un peu plus straight forward il me semble

J'ai aussi gérer l'import des attributs de perso que j'avais zappé dans une autre PR


J'ai skip l'écriture de tests sur les hooks/composants principaux pour pouvoir sortir ça d'ici la fin du build, mais il faudrait le faire


Close #456