### PR TITLE
:bug: Fix wiki link text centering and icon positioning in builder

### DIFF
--- a/client/src/builder/components/lexical-node-wiki-article-editor.tsx
+++ b/client/src/builder/components/lexical-node-wiki-article-editor.tsx
@@ -273,9 +273,9 @@ export const EditorWikiNodeComponent = ({ node }: { node: WikiNode }) => {
 
   return (
     <Popover>
-      <PopoverTrigger>
-        <span className="inline-flex translate-y-0.5 items-center gap-1 rounded-xl bg-green-600/60 px-2">
-          <ScrollTextIcon size={18} className="opacity-75" />
+      <PopoverTrigger asChild>
+        <span className="inline-flex translate-y-0.5 items-start gap-1 rounded-xl bg-green-600/60 px-2 text-left">
+          <ScrollTextIcon size={18} className="mt-0.5 shrink-0 opacity-75" />
           {node.textContent}
         </span>
       </PopoverTrigger>


### PR DESCRIPTION
# Résumé
  - Fix du centrage du texte linké wiki dans l'éditeur de scène du builder
  quand le texte est assez long pour aller à la ligne
  - Fix du positionnement du logo wiki (icône 📜) qui se centrait
  verticalement au lieu de rester en haut à gauche

  ## Changements
  - Ajout de `asChild` sur `PopoverTrigger` pour supprimer le `<button>`
  implicite qui centrait le texte (cohérent avec le reste du codebase)
  - Remplacement de `items-center` par `items-start` pour que l'icône reste
  alignée avec la première ligne
  - Ajout de `text-left` pour forcer l'alignement à gauche
  - Ajout de `shrink-0` sur l'icône pour éviter qu'elle rétrécisse

Closes #341