### PR TITLE
386 ux déplacer actions dnd form édition scène

### DIFF
--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -1,6 +1,7 @@
 import { Controller, FieldArrayWithId } from "react-hook-form";
 import { Button, Input } from "@/design-system/primitives";
-import { SettingsIcon, Trash2Icon } from "lucide-react";
+import { GripVerticalIcon, SettingsIcon, Trash2Icon } from "lucide-react";
+import { DragEvent } from "react";
 import { FormError } from "@/design-system/components";
 import {
   Select,
@@ -28,6 +29,13 @@ import {
 } from "./hooks/use-condition-change";
 import { Separator } from "@/design-system/primitives/separator";
 
+export type DragHandlers = {
+  onDragStart: (e: DragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: DragEvent<HTMLDivElement>) => void;
+  onDragEnd: (e: DragEvent<HTMLDivElement>) => void;
+};
+
 const useConditionOptions = ({
   hasCharacterConfig,
 }: {
@@ -46,6 +54,10 @@ const useConditionOptions = ({
   return options;
 };
 
+const setDragOver = (e: DragEvent<HTMLDivElement>, value: string) => {
+  e.currentTarget.dataset.dragOver = value;
+};
+
 // TODO: test this
 export const ActionItem = ({
   actionField,
@@ -53,12 +65,14 @@ export const ActionItem = ({
   actionIndex,
   characterConfig,
   removeAction,
+  dragHandlers,
 }: {
   actionField: FieldArrayWithId<EditActionsSchema, "actions", "id">;
   form: EditActionsForm;
   actionIndex: number;
   characterConfig: CharacterConfiguration | null;
   removeAction: (index: number) => void;
+  dragHandlers: DragHandlers;
 }) => {
   const hasCharacterConfig =
     Object.keys(characterConfig?.attributes ?? {}).length > 0;
@@ -82,8 +96,32 @@ export const ActionItem = ({
   const conditionOptions = useConditionOptions({ hasCharacterConfig });
 
   return (
-    <div className="my-2" key={actionField.id}>
+    <div
+      className="my-2 border-t-2 border-transparent data-[drag-over=true]:border-primary"
+      key={actionField.id}
+      draggable
+      onDragStart={dragHandlers.onDragStart}
+      onDragOver={(e) => {
+        dragHandlers.onDragOver(e);
+        setDragOver(e, "true");
+      }}
+      onDragLeave={(e) => {
+        setDragOver(e, "false");
+      }}
+      onDrop={(e) => {
+        dragHandlers.onDrop(e);
+        setDragOver(e, "false");
+      }}
+      onDragEnd={(e) => {
+        dragHandlers.onDragEnd(e);
+        setDragOver(e, "false");
+      }}
+    >
       <div className="flex items-center gap-2">
+        <GripVerticalIcon
+          size={18}
+          className="shrink-0 cursor-grab text-muted-foreground active:cursor-grabbing"
+        />
         <Controller
           control={form.control}
           name={`actions.${actionIndex}.text`}

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -32,6 +32,7 @@ import { Separator } from "@/design-system/primitives/separator";
 export type DragHandlers = {
   onDragStart: (e: DragEvent<HTMLDivElement>) => void;
   onDragOver: (e: DragEvent<HTMLDivElement>) => void;
+  onDragLeave: (e: DragEvent<HTMLDivElement>) => void;
   onDrop: (e: DragEvent<HTMLDivElement>) => void;
   onDragEnd: (e: DragEvent<HTMLDivElement>) => void;
 };
@@ -52,10 +53,6 @@ const useConditionOptions = ({
   };
 
   return options;
-};
-
-const setDragOver = (e: DragEvent<HTMLDivElement>, value: string) => {
-  e.currentTarget.dataset.dragOver = value;
 };
 
 // TODO: test this
@@ -97,25 +94,14 @@ export const ActionItem = ({
 
   return (
     <div
-      className="data-[drag-over=true]:border-primary my-2 border-t-2 border-transparent"
+      className="relative my-2 before:pointer-events-none before:absolute before:left-0 before:right-0 before:h-0.5 before:bg-transparent data-[drag-over=above]:before:-top-[5px] data-[drag-over=above]:before:bg-primary data-[drag-over=below]:before:-bottom-[5px] data-[drag-over=below]:before:bg-primary"
       key={actionField.id}
       draggable
       onDragStart={dragHandlers.onDragStart}
-      onDragOver={(e) => {
-        dragHandlers.onDragOver(e);
-        setDragOver(e, "true");
-      }}
-      onDragLeave={(e) => {
-        setDragOver(e, "false");
-      }}
-      onDrop={(e) => {
-        dragHandlers.onDrop(e);
-        setDragOver(e, "false");
-      }}
-      onDragEnd={(e) => {
-        dragHandlers.onDragEnd(e);
-        setDragOver(e, "false");
-      }}
+      onDragOver={dragHandlers.onDragOver}
+      onDragLeave={dragHandlers.onDragLeave}
+      onDrop={dragHandlers.onDrop}
+      onDragEnd={dragHandlers.onDragEnd}
     >
       <div className="flex items-center gap-2">
         <GripVerticalIcon

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -97,7 +97,7 @@ export const ActionItem = ({
 
   return (
     <div
-      className="my-2 border-t-2 border-transparent data-[drag-over=true]:border-primary"
+      className="data-[drag-over=true]:border-primary my-2 border-t-2 border-transparent"
       key={actionField.id}
       draggable
       onDragStart={dragHandlers.onDragStart}
@@ -120,7 +120,7 @@ export const ActionItem = ({
       <div className="flex items-center gap-2">
         <GripVerticalIcon
           size={18}
-          className="shrink-0 cursor-grab text-muted-foreground active:cursor-grabbing"
+          className="text-muted-foreground shrink-0 cursor-grab active:cursor-grabbing"
         />
         <Controller
           control={form.control}

--- a/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/action-item.tsx
@@ -94,7 +94,7 @@ export const ActionItem = ({
 
   return (
     <div
-      className="relative my-2 before:pointer-events-none before:absolute before:left-0 before:right-0 before:h-0.5 before:bg-transparent data-[drag-over=above]:before:-top-[5px] data-[drag-over=above]:before:bg-primary data-[drag-over=below]:before:-bottom-[5px] data-[drag-over=below]:before:bg-primary"
+      className="data-[drag-over=above]:before:bg-primary data-[drag-over=below]:before:bg-primary relative my-2 before:pointer-events-none before:absolute before:right-0 before:left-0 before:h-0.5 before:bg-transparent data-[drag-over=above]:before:-top-[5px] data-[drag-over=below]:before:-bottom-[5px]"
       key={actionField.id}
       draggable
       onDragStart={dragHandlers.onDragStart}

--- a/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
@@ -5,8 +5,37 @@ import { useBuilderActions } from "@/builder/hooks/use-builder-actions";
 import { useGetScene } from "@/builder/hooks/use-get-scene";
 import { SimpleLoader } from "@/design-system/components/simple-loader";
 import { CharacterConfiguration, Scene } from "@/lib/storage/domain";
+import { DragEvent, useRef } from "react";
 import { useGetCharacterConfig } from "@/builder/hooks/use-get-character-config";
-import { ActionItem } from "./action-item";
+import { ActionItem, DragHandlers } from "./action-item";
+
+const useActionDrag = (move: (from: number, to: number) => void) => {
+  const dragIndexRef = useRef<number | null>(null);
+
+  const getDragHandlers = (index: number): DragHandlers => ({
+    onDragStart(e: DragEvent<HTMLDivElement>) {
+      dragIndexRef.current = index;
+      e.dataTransfer.effectAllowed = "move";
+    },
+    onDragOver(e: DragEvent<HTMLDivElement>) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+    },
+    onDrop(e: DragEvent<HTMLDivElement>) {
+      e.preventDefault();
+      const fromIndex = dragIndexRef.current;
+      if (fromIndex !== null && fromIndex !== index) {
+        move(fromIndex, index);
+      }
+      dragIndexRef.current = null;
+    },
+    onDragEnd() {
+      dragIndexRef.current = null;
+    },
+  });
+
+  return { getDragHandlers };
+};
 
 const ActionsFormContent = ({
   scene,
@@ -16,7 +45,7 @@ const ActionsFormContent = ({
   characterConfig: CharacterConfiguration | null;
 }) => {
   const { updateScene, makeEmptyActionPayload } = useBuilderActions();
-  const { append, fields, form, remove } = useEditActionsForm({
+  const { append, fields, form, remove, move } = useEditActionsForm({
     actions: scene.actions,
     onSave: (payload) => updateScene({ key: scene.key, ...payload }),
   });
@@ -24,6 +53,8 @@ const ActionsFormContent = ({
   const removeAction = (index?: number | number[]) => {
     remove(index);
   };
+
+  const { getDragHandlers } = useActionDrag(move);
 
   return (
     <Form {...form}>
@@ -56,6 +87,7 @@ const ActionsFormContent = ({
                 actionIndex={actionIndex}
                 characterConfig={characterConfig}
                 removeAction={removeAction}
+                dragHandlers={getDragHandlers(actionIndex)}
               />
             ))}
           </div>

--- a/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/actions-form.tsx
@@ -20,6 +20,14 @@ const useActionDrag = (move: (from: number, to: number) => void) => {
     onDragOver(e: DragEvent<HTMLDivElement>) {
       e.preventDefault();
       e.dataTransfer.dropEffect = "move";
+      const dragIndex = dragIndexRef.current;
+      if (dragIndex !== null && dragIndex !== index) {
+        e.currentTarget.dataset.dragOver =
+          dragIndex < index ? "below" : "above";
+      }
+    },
+    onDragLeave(e: DragEvent<HTMLDivElement>) {
+      delete e.currentTarget.dataset.dragOver;
     },
     onDrop(e: DragEvent<HTMLDivElement>) {
       e.preventDefault();
@@ -27,6 +35,7 @@ const useActionDrag = (move: (from: number, to: number) => void) => {
       if (fromIndex !== null && fromIndex !== index) {
         move(fromIndex, index);
       }
+      delete e.currentTarget.dataset.dragOver;
       dragIndexRef.current = null;
     },
     onDragEnd() {

--- a/client/src/builder/hooks/use-edit-actions-form.ts
+++ b/client/src/builder/hooks/use-edit-actions-form.ts
@@ -22,7 +22,7 @@ export const useEditActionsForm = ({
     values: { actions },
   });
 
-  const { fields, append, remove, update } = useFieldArray({
+  const { fields, append, remove, update, move } = useFieldArray({
     name: "actions",
     control: form.control,
   });
@@ -32,7 +32,7 @@ export const useEditActionsForm = ({
     onSubmit: (values) => onSave({ actions: values.actions }),
   });
 
-  return { form, fields, append, remove, update };
+  return { form, fields, append, remove, update, move };
 };
 
 export type EditActionsForm = UseFormReturn<EditActionsSchema>;


### PR DESCRIPTION
## Résumé
  - Ajout du drag and drop pour réordonner les actions dans le formulaire
  d'édition de scène (onglet Actions)
  - Poignée de drag (icône grip) à gauche de chaque action
  - Indicateur visuel (ligne bleue) pour montrer où l'action sera déposée
  - Sauvegarde automatique après réordonnancement (auto-submit existant)

  ## Changements
  - `use-edit-actions-form.ts` : Expose `move` depuis `useFieldArray` de
  react-hook-form
  - `actions-form.tsx` : Nouveau hook `useActionDrag` encapsulant la logique
  de drag natif HTML (`dragStart/Over/Drop/End`)
  - `action-item.tsx` : Ajout du `GripVerticalIcon` comme handle de drag, type
   `DragHandlers` exporté, helper `setDragOver` pour l'indicateur visuel

  ## Choix techniques
  - HTML natif `draggable` — cohérent avec les patterns existants du repo
  (`file-input.tsx`, `images-plugin`), pas de nouvelle dépendance
  - `useFieldArray.move()` — déjà disponible dans react-hook-form, pas utilisé
   jusqu'ici

  Closes #386
