### PR TITLE
:sparkles: Add toast on Ctrl+S to inform auto-save

### DIFF
--- a/client/src/builder/hooks/use-builder-shortcuts.ts
+++ b/client/src/builder/hooks/use-builder-shortcuts.ts
@@ -7,6 +7,7 @@ import { useCopyPaste } from "./use-copy-paste";
 import { useEffect, useEffectEvent } from "react";
 import { useBuilderEditorStore } from "./use-builder-editor-store";
 import { useAddScene } from "./use-add-scene";
+import { toast } from "sonner";
 
 export const isAnyInputFocused = () => {
   const isInputFocused = document.activeElement?.tagName === "INPUT";
@@ -57,6 +58,12 @@ export const useBuilderShortCuts = ({
   };
 
   const handleKeyDown = useEffectEvent((e: KeyboardEvent) => {
+    const isCtrlOrMeta = getUserOS() === "Mac" ? e.metaKey : e.ctrlKey;
+    if (isCtrlOrMeta && e.key.toLocaleLowerCase() === "s") {
+      e.preventDefault();
+      if (!e.repeat) toast.info("Changes are automatically saved!");
+      return;
+    }
     if (e.isComposing || isAnyInputFocused()) return;
     const key = e.key.toLocaleLowerCase();
     for (const binding of Object.keys(shortcuts)) {


### PR DESCRIPTION
## Résumé
- Interception du Ctrl/Cmd+S dans le builder pour bloquer le popup par défaut du navigateur qui cherche à save le HTML
- Affichage d'un toast informant l'utilisateur que les changements sont automatiquement enregistrés

## Changements
- Ajout d'un handler Ctrl+S avant le check `isAnyInputFocused()` pour que ça fonctionne même quand un input est focus
- `e.preventDefault()` pour bloquer le comportement par défaut du navigateur
- Guard `!e.repeat` pour éviter de spam le toast en maintenant la touche
- Import de `toast` depuis sonner (déjà utilisé dans le projet)

Closes #425