### PR TITLE
Handle side effects in game

### DIFF
--- a/client/src/domains/game/__tests__/character-repository.test.ts
+++ b/client/src/domains/game/__tests__/character-repository.test.ts
@@ -20,7 +20,7 @@ describe("game character repository", () => {
 
   describe("get", () => {
     test("should return null if not exists", async () => {
-      const result = await repo.get("plouf");
+      const result = await repo.getConfig("plouf");
       expect(result).toBeNull();
     });
 
@@ -28,7 +28,7 @@ describe("game character repository", () => {
       const character = factory.characterConfig();
       await testDB.characterConfigurations.add(character);
 
-      const result = await repo.get(character.storyKey);
+      const result = await repo.getConfig(character.storyKey);
 
       expect(result).toStrictEqual(character);
     });

--- a/client/src/domains/game/__tests__/game-service.test.ts
+++ b/client/src/domains/game/__tests__/game-service.test.ts
@@ -13,12 +13,18 @@ import {
 import { getTestFactory } from "@/lib/testing/factory";
 import { nanoid } from "nanoid";
 import { randomInArray } from "@/lib/random";
+import {
+  getStubProgressRepository,
+  MockProgressRepository,
+} from "../stubs/progress-repository-stub";
+import { ProgressCharacter } from "@/lib/storage/domain";
 
 const factory = getTestFactory();
 
 describe("game-service", () => {
   let gameService: ReturnType<typeof _getGameService>;
   let localRepository: MockLocalRepository;
+  let progressRepo: MockProgressRepository;
 
   beforeAll(() => {
     vi.useFakeTimers();
@@ -27,71 +33,91 @@ describe("game-service", () => {
 
   beforeEach(async () => {
     localRepository = getLocalRepositoryStub();
+    progressRepo = getStubProgressRepository();
 
     gameService = _getGameService({
       localRepository,
+      progressRepo,
     });
   });
 
   describe("saveProgress", () => {
     it("should save the story progress in the local database", async () => {
-      await gameService.saveProgress(BASIC_STORY_PROGRESS.key, {
-        currentSceneKey: "tutu",
-        sceneActions: [
-          { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
-        ],
-      });
-
-      expect(localRepository.getStoryProgress).toHaveBeenCalledWith(
+      progressRepo.get.mockResolvedValue(BASIC_STORY_PROGRESS);
+      await gameService.saveProgress(
         BASIC_STORY_PROGRESS.key,
+        factory.scene({
+          key: "tutu",
+          actions: [
+            {
+              key: "action-key",
+              type: "simple",
+              targets: [],
+              text: "bzz bzz",
+            },
+          ],
+          sideEffects: [],
+        }),
       );
+
+      expect(progressRepo.get).toHaveBeenCalledWith(BASIC_STORY_PROGRESS.key);
       expect(localRepository.getUser).toHaveBeenCalled();
-      expect(localRepository.updateStoryProgress).toHaveBeenCalledWith({
-        ...BASIC_STORY_PROGRESS,
-        currentSceneKey: "tutu",
-        history: [...BASIC_STORY_PROGRESS.history, "tutu"],
-        lastPlayedAt: new Date(),
-        createdAt: BASIC_STORY_PROGRESS.createdAt,
-        userKey: BASIC_USER.key,
-      });
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        {
+          currentSceneKey: "tutu",
+          history: [...BASIC_STORY_PROGRESS.history, "tutu"],
+          lastPlayedAt: new Date(),
+          userKey: BASIC_USER.key,
+        },
+      );
     });
 
     it("should also work when the user is not logged in", async () => {
       localRepository.getUser.mockResolvedValueOnce(null);
+      progressRepo.get.mockResolvedValueOnce(BASIC_STORY_PROGRESS);
 
-      await gameService.saveProgress(BASIC_STORY_PROGRESS.key, {
-        currentSceneKey: "tutu",
-        sceneActions: [
-          { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
-        ],
-      });
+      await gameService.saveProgress(
+        BASIC_STORY_PROGRESS.key,
+        factory.scene({
+          key: "tutu",
+          actions: [
+            { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
+          ],
+          sideEffects: [],
+        }),
+      );
 
-      expect(localRepository.getStoryProgress).toHaveBeenCalled();
+      expect(progressRepo.get).toHaveBeenCalled();
       expect(localRepository.getUser).toHaveBeenCalled();
-      expect(localRepository.updateStoryProgress).toHaveBeenCalledWith({
-        ...BASIC_STORY_PROGRESS,
-        currentSceneKey: "tutu",
-        history: [...BASIC_STORY_PROGRESS.history, "tutu"],
-        lastPlayedAt: new Date(),
-        createdAt: BASIC_STORY_PROGRESS.createdAt,
-        userKey: undefined,
-      });
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        {
+          currentSceneKey: "tutu",
+          history: [...BASIC_STORY_PROGRESS.history, "tutu"],
+          lastPlayedAt: new Date(),
+          userKey: undefined,
+        },
+      );
     });
 
     it("should not add to history the same key twice in a row", async () => {
-      await gameService.saveProgress(BASIC_STORY_PROGRESS.key, {
-        currentSceneKey: BASIC_STORY_PROGRESS.history.at(-1)!,
-        sceneActions: [
-          { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
-        ],
-      });
+      progressRepo.get.mockResolvedValueOnce(BASIC_STORY_PROGRESS);
+      await gameService.saveProgress(
+        BASIC_STORY_PROGRESS.key,
+        factory.scene({
+          key: BASIC_STORY_PROGRESS.history.at(-1)!,
+          actions: [
+            { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
+          ],
+        }),
+      );
 
-      expect(localRepository.getStoryProgress).toHaveBeenCalled();
-      expect(localRepository.updateStoryProgress).toHaveBeenCalledWith({
-        ...BASIC_STORY_PROGRESS,
-        lastPlayedAt: new Date(),
-        createdAt: BASIC_STORY_PROGRESS.createdAt,
-      });
+      expect(progressRepo.get).toHaveBeenCalled();
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        { lastPlayedAt: new Date(), userKey: expect.any(String) },
+      );
     });
 
     it("should keep revisits in history when they are not consecutive", async () => {
@@ -100,17 +126,20 @@ describe("game-service", () => {
         history: ["scene-a", "scene-b"],
         currentSceneKey: "scene-b",
       };
-      localRepository.getStoryProgress.mockResolvedValue(existingProgress);
+      progressRepo.get.mockResolvedValue(existingProgress);
 
-      await gameService.saveProgress(BASIC_STORY_PROGRESS.key, {
-        currentSceneKey: "scene-a",
-        sceneActions: [
-          { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
-        ],
-      });
+      await gameService.saveProgress(
+        BASIC_STORY_PROGRESS.key,
+        factory.scene({
+          key: "scene-a",
+          actions: [
+            { key: "action-key", type: "simple", targets: [], text: "bzz bzz" },
+          ],
+          sideEffects: [],
+        }),
+      );
 
-      expect(localRepository.updateStoryProgress).toHaveBeenCalledWith({
-        ...existingProgress,
+      expect(progressRepo.update).toHaveBeenCalledWith(existingProgress.key, {
         currentSceneKey: "scene-a",
         history: ["scene-a", "scene-b", "scene-a"],
         lastPlayedAt: new Date(),
@@ -119,23 +148,144 @@ describe("game-service", () => {
     });
 
     it("should mark as finished if the story ends on this scene", async () => {
-      await gameService.saveProgress(BASIC_STORY_PROGRESS.key, {
-        currentSceneKey: "bim",
-        sceneActions: [],
+      progressRepo.get.mockResolvedValueOnce(BASIC_STORY_PROGRESS);
+      await gameService.saveProgress(
+        BASIC_STORY_PROGRESS.key,
+        factory.scene({
+          key: "bim",
+          actions: [],
+          sideEffects: [],
+        }),
+      );
+
+      expect(progressRepo.get).toHaveBeenCalled();
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        {
+          currentSceneKey: "bim",
+          history: [...BASIC_STORY_PROGRESS.history, "bim"],
+          lastPlayedAt: new Date(),
+          userKey: expect.any(String),
+          finished: true,
+        },
+      );
+    });
+
+    describe("side effects", () => {
+      const PROGRESS_CHARACTER = {
+        attributes: {
+          "dex-key": {
+            key: "dex-key",
+            initialValue: 10,
+            name: "dexterity",
+            type: "numeric",
+            visibility: "invisible",
+            value: 10,
+          },
+        },
+      } satisfies ProgressCharacter;
+
+      const _setUpSideEffects = () => {
+        const effect = factory.sideEffect({
+          effect: {
+            attributeKey: "dex-key",
+            increment: 5,
+            type: "character-attribute",
+          },
+        });
+
+        const scene = factory.scene({ sideEffects: [effect] });
+
+        return { progressCharacter: PROGRESS_CHARACTER, scene };
+      };
+
+      it("should fail when character does not exist", async () => {
+        const { scene } = _setUpSideEffects();
+        const progress = factory.storyProgress({
+          key: "tutu",
+          character: undefined, // No character on progress
+          currentSceneKey: "scene-2",
+          history: ["scene-1", "scene-2"],
+        });
+        progressRepo.get.mockResolvedValue(progress);
+
+        await expect(
+          gameService.saveProgress(progress.key, scene),
+        ).rejects.toThrowError();
+        expect(progressRepo.update).not.toHaveBeenCalled();
       });
 
-      expect(localRepository.getStoryProgress).toHaveBeenCalled();
-      expect(localRepository.updateStoryProgress).toHaveBeenCalledWith({
-        ...BASIC_STORY_PROGRESS,
-        currentSceneKey: "bim",
-        history: [...BASIC_STORY_PROGRESS.history, "bim"],
-        lastPlayedAt: new Date(),
-        createdAt: BASIC_STORY_PROGRESS.createdAt,
-        userKey: BASIC_USER.key,
-        finished: true,
+      it("should fail when character attribute does not exist", async () => {
+        const { scene } = _setUpSideEffects();
+        const progress = factory.storyProgress({
+          key: "tutu",
+          character: factory.progressCharacter(), // New random character, so that the scene's side effects won't match the character attributes
+          currentSceneKey: "scene-2",
+          history: ["scene-1", "scene-2"],
+        });
+        progressRepo.get.mockResolvedValue(progress);
+
+        await expect(
+          gameService.saveProgress(progress.key, scene),
+        ).rejects.toThrowError();
+        expect(progressRepo.update).not.toHaveBeenCalled();
+      });
+
+      it("should not trigger side effects when revisiting the same scene consecutively", async () => {
+        const { progressCharacter, scene } = _setUpSideEffects();
+        const progress = factory.storyProgress({
+          key: "tutu",
+          character: progressCharacter,
+          currentSceneKey: scene.key,
+          history: ["scene-1", "scene-2", scene.key],
+        });
+        progressRepo.get.mockResolvedValue(progress);
+
+        await gameService.saveProgress("tutu", scene);
+
+        expect(progressRepo.update).toHaveBeenCalledOnce();
+        expect(progressRepo.update).toHaveBeenCalledWith("tutu", {
+          // Nothing is updated except for the date
+          lastPlayedAt: new Date(),
+          userKey: expect.any(String),
+        });
+      });
+
+      it("should update character with ", async () => {
+        const { progressCharacter, scene } = _setUpSideEffects();
+        const progress = factory.storyProgress({
+          key: "tutu",
+          character: progressCharacter,
+          currentSceneKey: "scene-2",
+          history: ["scene-1", "scene-2"],
+        });
+        progressRepo.get.mockResolvedValue(progress);
+
+        await gameService.saveProgress("tutu", scene);
+
+        expect(progressRepo.update).toHaveBeenCalledOnce();
+        expect(progressRepo.update).toHaveBeenCalledWith("tutu", {
+          currentSceneKey: scene.key,
+          history: ["scene-1", "scene-2", scene.key],
+          lastPlayedAt: new Date(),
+          userKey: expect.any(String),
+          character: {
+            attributes: {
+              "dex-key": {
+                key: "dex-key",
+                initialValue: 10,
+                name: "dexterity",
+                type: "numeric",
+                visibility: "invisible",
+                value: 15, // 10 + 5
+              },
+            },
+          },
+        });
       });
     });
   });
+  it("should not trigger side effects when revisiting the same scene consecutively", () => {});
 
   describe("getActionVisibility", () => {
     test("simple actions are always visible", () => {
@@ -490,7 +640,7 @@ describe("game-service", () => {
     it("should return null story and null scenes if storyKey is invalid", async () => {
       localRepository.getStory.mockResolvedValueOnce(null);
 
-      gameService = _getGameService({ localRepository });
+      gameService = _getGameService({ localRepository, progressRepo });
 
       const { story, scene } =
         await gameService.getFirstSceneData("pipoupipou");
@@ -505,11 +655,11 @@ describe("game-service", () => {
 
   describe("getStoryProgress", () => {
     it("should retrieve story progress", async () => {
+      progressRepo.get.mockResolvedValueOnce(BASIC_STORY_PROGRESS);
+
       const p = await gameService.getStoryProgress("viooooooum");
 
-      expect(localRepository.getStoryProgress).toHaveBeenCalledWith(
-        "viooooooum",
-      );
+      expect(progressRepo.get).toHaveBeenCalledWith("viooooooum");
 
       expect(p).toStrictEqual(BASIC_STORY_PROGRESS);
     });

--- a/client/src/domains/game/__tests__/library-service.test.ts
+++ b/client/src/domains/game/__tests__/library-service.test.ts
@@ -281,7 +281,7 @@ describe("library-service", () => {
   describe("createBlankStoryProgress", () => {
     test("simple story configuration", async () => {
       localRepository.getStoryProgress.mockResolvedValueOnce(null);
-      characterRepository.get.mockResolvedValueOnce(null);
+      characterRepository.getConfig.mockResolvedValueOnce(null);
 
       const createdProgress = await libraryService.createBlankStoryProgress({
         storyKey: BASIC_STORY.key,
@@ -322,7 +322,7 @@ describe("library-service", () => {
         },
       });
       localRepository.getStoryProgress.mockResolvedValueOnce(null);
-      characterRepository.get.mockResolvedValueOnce(cc);
+      characterRepository.getConfig.mockResolvedValueOnce(cc);
 
       await libraryService.createBlankStoryProgress({
         storyKey: BASIC_STORY.key,

--- a/client/src/domains/game/character-repository.ts
+++ b/client/src/domains/game/character-repository.ts
@@ -2,13 +2,13 @@ import { db, DexieDatabase } from "@/lib/storage/dexie/dexie-db";
 import { CharacterConfiguration } from "@/lib/storage/domain";
 
 export type CharacterRepositoryPort = {
-  get: (storyKey: string) => Promise<CharacterConfiguration | null>;
+  getConfig: (storyKey: string) => Promise<CharacterConfiguration | null>;
 };
 
 export const _getDexieCharacterRepository = (
   db: DexieDatabase,
 ): CharacterRepositoryPort => {
-  const get = async (storyKey: string) => {
+  const getConfig = async (storyKey: string) => {
     const characters = await db.characterConfigurations
       .filter((character) => character.storyKey === storyKey)
       .toArray();
@@ -16,7 +16,7 @@ export const _getDexieCharacterRepository = (
     return characters[0] ?? null;
   };
 
-  return { get };
+  return { getConfig };
 };
 
 export const getDexieCharacterRepository = () =>

--- a/client/src/domains/game/game-repository.ts
+++ b/client/src/domains/game/game-repository.ts
@@ -5,6 +5,7 @@ import { Scene } from "@/lib/storage/domain";
 export type GameRepositoryPort = {
   deleteWiki: (gameKey: string) => Promise<void>;
   getScenes: (gameKey: string) => Promise<Scene[]>;
+  getScene: (sceneKey: string) => Promise<Scene | null>;
 };
 
 export const _getDexieGameRepository = (
@@ -33,6 +34,10 @@ export const _getDexieGameRepository = (
       return await db.scenes
         .filter((scene) => scene.storyKey === gameKey)
         .toArray();
+    },
+
+    getScene: async (sceneKey: string) => {
+      return (await db.scenes.get(sceneKey)) ?? null;
     },
   };
 };

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -1,4 +1,10 @@
-import { Action, Scene, Story, StoryProgress } from "@/lib/storage/domain";
+import {
+  Action,
+  Scene,
+  SideEffect,
+  Story,
+  StoryProgress,
+} from "@/lib/storage/domain";
 import { getLocalRepository, LocalRepositoryPort } from "@/repositories";
 import { match } from "ts-pattern";
 import { produce } from "immer";
@@ -13,7 +19,7 @@ type GameServicePort = {
     currentScene: Scene,
   ) => Promise<{
     updatedProgress: StoryProgress | null;
-    effectsTriggered: number;
+    effectsTriggered: SideEffect[];
   }>;
   getNextKey: (
     options: {
@@ -68,9 +74,9 @@ export const _getGameService = ({
     progress: StoryProgress;
   }) => {
     if ((scene.sideEffects ?? []).length <= 0)
-      return { updatedCharacter: null, effectsTriggered: 0 };
+      return { updatedCharacter: null, effectsTriggered: [] };
 
-    let effectsTriggered = 0;
+    const effectsTriggered: SideEffect[] = [];
     const updatedCharacter =
       produce(progress.character, (character) => {
         if (!character)
@@ -88,7 +94,7 @@ export const _getGameService = ({
             );
 
           attribute.value += effectConfig.effect.increment;
-          effectsTriggered += 1;
+          effectsTriggered.push(effectConfig);
         });
       }) ?? null;
 
@@ -106,7 +112,7 @@ export const _getGameService = ({
       const isImmediateDuplicate = progress.history.at(-1) === currentScene.key;
 
       let updatedProgress: StoryProgress | null = null;
-      let effectsTriggered = 0;
+      const effectsTriggered: SideEffect[] = [];
 
       if (isImmediateDuplicate) {
         updatedProgress = { ...progress, lastPlayedAt: new Date() };
@@ -129,7 +135,7 @@ export const _getGameService = ({
             character: effectsResult.updatedCharacter,
           }),
         };
-        effectsTriggered = effectsResult.effectsTriggered;
+        effectsTriggered.push(...effectsResult.effectsTriggered);
       }
 
       await progressRepo.update(progress.key, updatedProgress);

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -77,7 +77,6 @@ export const _getGameService = ({
       return { updatedCharacter: null, effectsTriggered: [] };
 
     const effectsTriggered: SideEffect[] = [];
-    console.log(progress);
     if (!progress.character)
       throw new Error(`Character does not exist on progress ${progress.key}`);
 

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -77,13 +77,12 @@ export const _getGameService = ({
       return { updatedCharacter: null, effectsTriggered: [] };
 
     const effectsTriggered: SideEffect[] = [];
+    console.log(progress);
+    if (!progress.character)
+      throw new Error(`Character does not exist on progress ${progress.key}`);
+
     const updatedCharacter =
       produce(progress.character, (character) => {
-        if (!character)
-          throw new Error(
-            `Character does not exist on progress ${progress.key}`,
-          );
-
         scene.sideEffects!.forEach((effectConfig) => {
           const attribute =
             character.attributes[effectConfig.effect.attributeKey];
@@ -104,18 +103,19 @@ export const _getGameService = ({
   return {
     saveProgress: async (storyProgressKey, currentScene) => {
       const user = await localRepository.getUser();
-      const progress = await localRepository.getStoryProgress(storyProgressKey);
+      const progress = await progressRepo.get(storyProgressKey);
 
       if (!progress)
         throw new Error(`No progress found for story ${storyProgressKey}`);
 
       const isImmediateDuplicate = progress.history.at(-1) === currentScene.key;
 
-      let updatedProgress: StoryProgress | null = null;
+      let updatePayload: Partial<StoryProgress> = {};
       const effectsTriggered: SideEffect[] = [];
+      console.log({ isImmediateDuplicate });
 
       if (isImmediateDuplicate) {
-        updatedProgress = { ...progress, lastPlayedAt: new Date() };
+        updatePayload = { userKey: user?.key, lastPlayedAt: new Date() };
       } else {
         const newHistory = [...progress.history, currentScene.key];
 
@@ -124,8 +124,7 @@ export const _getGameService = ({
           progress,
         });
 
-        updatedProgress = {
-          ...progress,
+        updatePayload = {
           currentSceneKey: currentScene.key,
           history: newHistory,
           lastPlayedAt: new Date(),
@@ -138,9 +137,12 @@ export const _getGameService = ({
         effectsTriggered.push(...effectsResult.effectsTriggered);
       }
 
-      await progressRepo.update(progress.key, updatedProgress);
+      await progressRepo.update(progress.key, updatePayload);
 
-      return { updatedProgress, effectsTriggered };
+      return {
+        updatedProgress: { ...progress, ...updatePayload },
+        effectsTriggered,
+      };
     },
 
     getNextKey: (options) => {
@@ -209,7 +211,7 @@ export const _getGameService = ({
     },
 
     getStoryProgress: async (storyKey) => {
-      return await localRepository.getStoryProgress(storyKey);
+      return await progressRepo.get(storyKey);
     },
 
     getStoryProgresses,

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -1,15 +1,20 @@
 import { Action, Scene, Story, StoryProgress } from "@/lib/storage/domain";
 import { getLocalRepository, LocalRepositoryPort } from "@/repositories";
 import { match } from "ts-pattern";
+import { produce } from "immer";
+import {
+  getDexieProgressRepository,
+  ProgressRepositoryPort,
+} from "./progress-repository";
 
 type GameServicePort = {
   saveProgress: (
     storyProgressKey: string,
-    params: {
-      currentSceneKey: string;
-      sceneActions: Action[];
-    },
-  ) => Promise<StoryProgress | null>;
+    currentScene: Scene,
+  ) => Promise<{
+    updatedProgress: StoryProgress | null;
+    effectsTriggered: number;
+  }>;
   getNextKey: (
     options: {
       sceneKey: string;
@@ -43,8 +48,10 @@ type GameServicePort = {
 
 export const _getGameService = ({
   localRepository,
+  progressRepo,
 }: {
   localRepository: LocalRepositoryPort;
+  progressRepo: ProgressRepositoryPort;
 }): GameServicePort => {
   const getStoryProgresses = async () => {
     const user = await localRepository.getUser();
@@ -53,32 +60,81 @@ export const _getGameService = ({
     return progresses;
   };
 
+  const _triggerSideEffects = async ({
+    scene,
+    progress,
+  }: {
+    scene: Scene;
+    progress: StoryProgress;
+  }) => {
+    if ((scene.sideEffects ?? []).length <= 0)
+      return { updatedCharacter: null, effectsTriggered: 0 };
+
+    let effectsTriggered = 0;
+    const updatedCharacter =
+      produce(progress.character, (character) => {
+        if (!character)
+          throw new Error(
+            `Character does not exist on progress ${progress.key}`,
+          );
+
+        scene.sideEffects!.forEach((effectConfig) => {
+          const attribute =
+            character.attributes[effectConfig.effect.attributeKey];
+
+          if (!attribute)
+            throw new Error(
+              `Attribute ${effectConfig.effect.attributeKey} does not exist on progress ${progress.key}`,
+            );
+
+          attribute.value += effectConfig.effect.increment;
+          effectsTriggered += 1;
+        });
+      }) ?? null;
+
+    return { updatedCharacter, effectsTriggered };
+  };
+
   return {
-    saveProgress: async (
-      storyProgressKey,
-      { currentSceneKey, sceneActions },
-    ) => {
+    saveProgress: async (storyProgressKey, currentScene) => {
       const user = await localRepository.getUser();
       const progress = await localRepository.getStoryProgress(storyProgressKey);
 
       if (!progress)
         throw new Error(`No progress found for story ${storyProgressKey}`);
 
-      const isImmediateDuplicate = progress.history.at(-1) === currentSceneKey;
-      const newHistory = isImmediateDuplicate
-        ? progress.history
-        : [...progress.history, currentSceneKey];
+      const isImmediateDuplicate = progress.history.at(-1) === currentScene.key;
 
-      const updatedProgress = await localRepository.updateStoryProgress({
-        ...progress,
-        currentSceneKey,
-        history: newHistory,
-        lastPlayedAt: new Date(),
-        ...(!sceneActions.length && { finished: true }),
-        userKey: user?.key,
-      });
+      let updatedProgress: StoryProgress | null = null;
+      let effectsTriggered = 0;
 
-      return updatedProgress;
+      if (isImmediateDuplicate) {
+        updatedProgress = { ...progress, lastPlayedAt: new Date() };
+      } else {
+        const newHistory = [...progress.history, currentScene.key];
+
+        const effectsResult = await _triggerSideEffects({
+          scene: currentScene,
+          progress,
+        });
+
+        updatedProgress = {
+          ...progress,
+          currentSceneKey: currentScene.key,
+          history: newHistory,
+          lastPlayedAt: new Date(),
+          userKey: user?.key,
+          ...(!currentScene.actions.length && { finished: true }),
+          ...(effectsResult.updatedCharacter && {
+            character: effectsResult.updatedCharacter,
+          }),
+        };
+        effectsTriggered = effectsResult.effectsTriggered;
+      }
+
+      await progressRepo.update(progress.key, updatedProgress);
+
+      return { updatedProgress, effectsTriggered };
     },
 
     getNextKey: (options) => {
@@ -157,4 +213,5 @@ export const _getGameService = ({
 export const getGameService = () =>
   _getGameService({
     localRepository: getLocalRepository(),
+    progressRepo: getDexieProgressRepository(),
   });

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -112,7 +112,6 @@ export const _getGameService = ({
 
       let updatePayload: Partial<StoryProgress> = {};
       const effectsTriggered: SideEffect[] = [];
-      console.log({ isImmediateDuplicate });
 
       if (isImmediateDuplicate) {
         updatePayload = { userKey: user?.key, lastPlayedAt: new Date() };

--- a/client/src/domains/game/library-service.ts
+++ b/client/src/domains/game/library-service.ts
@@ -58,7 +58,7 @@ export const _getLibraryService = ({
   }) => {
     const user = await localRepository.getUser();
     const story = await localRepository.getStory(storyKey);
-    const characterConfig = await characterRepository.get(storyKey);
+    const characterConfig = await characterRepository.getConfig(storyKey);
 
     if (!story) throw new Error(`Error: invalid story key: ${storyKey}`);
 

--- a/client/src/domains/game/progress-repository.ts
+++ b/client/src/domains/game/progress-repository.ts
@@ -3,6 +3,10 @@ import { StoryProgress } from "@/lib/storage/domain";
 
 export type ProgressRepositoryPort = {
   get: (progressKey: string) => Promise<StoryProgress | null>;
+  update: (
+    progressKey: string,
+    progress: Partial<StoryProgress>,
+  ) => Promise<void>;
 };
 
 export const _getDexieProgressRepository = (
@@ -11,6 +15,9 @@ export const _getDexieProgressRepository = (
   return {
     get: async (progressKey) => {
       return (await db.storyProgresses.get(progressKey)) ?? null;
+    },
+    update: async (progressKey, progress) => {
+      await db.storyProgresses.update(progressKey, progress);
     },
   };
 };

--- a/client/src/domains/game/stubs/game-repository-stub.ts
+++ b/client/src/domains/game/stubs/game-repository-stub.ts
@@ -11,5 +11,6 @@ export const getStubGameRepository = (): MockGameRepository => {
   return {
     deleteWiki: vi.fn(),
     getScenes: vi.fn(() => Promise.resolve([factory.scene(), factory.scene()])),
+    getScene: vi.fn(),
   };
 };

--- a/client/src/domains/game/stubs/progress-repository-stub.ts
+++ b/client/src/domains/game/stubs/progress-repository-stub.ts
@@ -10,5 +10,6 @@ const factory = getTestFactory();
 export const getStubProgressRepository = (): MockProgressRepository => {
   return {
     get: vi.fn(() => Promise.resolve(factory.storyProgress())),
+    update: vi.fn(),
   };
 };

--- a/client/src/domains/game/stubs/stub-character-repository.ts
+++ b/client/src/domains/game/stubs/stub-character-repository.ts
@@ -7,5 +7,5 @@ const factory = getTestFactory();
 export type MockCharacterRepository = MockPort<CharacterRepositoryPort>;
 
 export const getStubCharacterRepository = (): MockCharacterRepository => ({
-  get: vi.fn(() => Promise.resolve(factory.characterConfig())),
+  getConfig: vi.fn(() => Promise.resolve(factory.characterConfig())),
 });

--- a/client/src/game/components/character-card.tsx
+++ b/client/src/game/components/character-card.tsx
@@ -5,18 +5,49 @@ import {
   CardHeader,
   CardTitle,
 } from "@/design-system/primitives";
-import { ProgressCharacter } from "@/lib/storage/domain";
+import { ProgressCharacter, SideEffect } from "@/lib/storage/domain";
 import {
   ArrowDownFromLineIcon,
   ArrowUpFromLineIcon,
   BookUserIcon,
 } from "lucide-react";
 import { useLocalGameSettings } from "../hooks/use-local-game-settings";
+import React from "react";
+import { cn } from "@/lib/style";
+
+const CharacterAttribute = ({
+  name,
+  value,
+  triggeredEffect,
+}: {
+  name: string;
+  value: number;
+  triggeredEffect?: SideEffect; // The eventual effect that was just triggered on this specific attribute
+}) => {
+  const shouldShowUpdate = triggeredEffect?.isVisible;
+
+  return (
+    <div>
+      <span className="font-semibold select-none">{name}:&nbsp;</span>
+      <span className={cn("select-none", shouldShowUpdate && "font-semibold")}>
+        {value}
+        {shouldShowUpdate && (
+          <span className="animate-pulse align-text-top text-xs font-normal text-emerald-600 select-none">
+            &nbsp;({triggeredEffect.effect.increment >= 0 ? "+" : "-"}
+            {triggeredEffect.effect.increment})
+          </span>
+        )}
+      </span>
+    </div>
+  );
+};
 
 export const CharacterCard = ({
   character,
+  triggeredSideEffects,
 }: {
   character?: ProgressCharacter;
+  triggeredSideEffects: SideEffect[];
 }) => {
   const shouldDisplayCharacter = Object.values(
     character?.attributes ?? {},
@@ -26,21 +57,21 @@ export const CharacterCard = ({
   if (!shouldDisplayCharacter) return null;
 
   return (
-    <Card className="gap-1 py-2">
-      <CardHeader
-        className="flex items-center justify-between"
-        onClick={() => {
-          setSettings((prev) => ({
-            isCharacterCardOpen: !prev.isCharacterCardOpen,
-          }));
-        }}
-      >
-        <CardTitle className="flex items-center gap-1">
+    <Card
+      className="gap-1 py-2"
+      onClick={() => {
+        setSettings((prev) => ({
+          isCharacterCardOpen: !prev.isCharacterCardOpen,
+        }));
+      }}
+    >
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle className="flex items-center gap-1 select-none">
           <BookUserIcon size={18} /> Your character
         </CardTitle>
         <Button
           variant="ghost"
-          size="icon-sm"
+          size="icon-xs"
           onClick={() => {
             setSettings((prev) => ({
               isCharacterCardOpen: !prev.isCharacterCardOpen,
@@ -59,13 +90,18 @@ export const CharacterCard = ({
         <CardContent className="flex flex-wrap gap-1">
           {Object.values(character!.attributes).map(
             ({ key, name, value }, i) => (
-              <div key={key}>
-                <span className="font-semibold">{name}:&nbsp;</span>
-                <span>{value}</span>
+              <React.Fragment key={key}>
+                <CharacterAttribute
+                  name={name}
+                  value={value}
+                  triggeredEffect={triggeredSideEffects.find(
+                    (effectConfig) => effectConfig.effect.attributeKey === key,
+                  )}
+                />
                 {i !== Object.keys(character!.attributes).length - 1 && (
-                  <span>&nbsp;·</span>
+                  <span className="select-none">&nbsp;·</span>
                 )}
-              </div>
+              </React.Fragment>
             ),
           )}
         </CardContent>

--- a/client/src/game/components/character-card.tsx
+++ b/client/src/game/components/character-card.tsx
@@ -53,12 +53,19 @@ export const CharacterCard = ({
     character?.attributes ?? {},
   ).some((attr) => attr.visibility === "visible");
   const [{ isCharacterCardOpen }, setSettings] = useLocalGameSettings();
+  const wereCharacterSideEffectsTriggered =
+    triggeredSideEffects.filter(
+      (se) => se.effect.type === "character-attribute",
+    ).length > 0;
 
   if (!shouldDisplayCharacter) return null;
 
   return (
     <Card
-      className="gap-1 py-2"
+      className={cn(
+        "gap-1 py-2",
+        wereCharacterSideEffectsTriggered && "ring-emerald-600",
+      )}
       onClick={() => {
         setSettings((prev) => ({
           isCharacterCardOpen: !prev.isCharacterCardOpen,

--- a/client/src/game/components/game-scene.tsx
+++ b/client/src/game/components/game-scene.tsx
@@ -2,7 +2,12 @@ import { SceneAction } from "./scene-action";
 import { Button } from "@/design-system/primitives";
 import { LibraryBigIcon } from "lucide-react";
 
-import { Scene, StoryProgress, StoryThemeConfig } from "@/lib/storage/domain";
+import {
+  Scene,
+  SideEffect,
+  StoryProgress,
+  StoryThemeConfig,
+} from "@/lib/storage/domain";
 import { Divider } from "@/design-system/components/divider";
 import { Link } from "@tanstack/react-router";
 import { RichText } from "@/design-system/components/editor/components/rich-text-editor";
@@ -15,6 +20,7 @@ type BaseProps = {
   scene: Scene;
   isLastScene: boolean;
   theme: StoryThemeConfig;
+  triggeredSideEffects: SideEffect[];
 };
 
 type GameModeProps = BaseProps & {
@@ -28,13 +34,13 @@ type ThemeEditorModeProps = BaseProps & { mode: "theme-editor" };
 
 type GameSceneProps = GameModeProps | TestModeProps | ThemeEditorModeProps;
 
-export const GameScene = (props: GameSceneProps) => {
-  const {
-    scene: { key, content, title, actions, storyKey },
-    isLastScene,
-    theme,
-  } = props;
-
+export const GameScene = ({
+  scene: { key, content, title, actions, storyKey },
+  isLastScene,
+  theme,
+  triggeredSideEffects,
+  ...props
+}: GameSceneProps) => {
   return (
     <div
       className="flex h-full w-full justify-center py-8"
@@ -50,7 +56,10 @@ export const GameScene = (props: GameSceneProps) => {
       <div className="w-11/12 px-6 lg:w-8/12">
         {/* TODO: enable progress in test mode (https://github.com/JeremieLeymarie/story-builder/issues/479) */}
         {props.mode === "game" && (
-          <CharacterCard character={props.progress.character} />
+          <CharacterCard
+            character={props.progress.character}
+            triggeredSideEffects={triggeredSideEffects}
+          />
         )}
         <div className="w-full py-4">
           <div>

--- a/client/src/game/components/scene-action.tsx
+++ b/client/src/game/components/scene-action.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/design-system/primitives";
 import { Action, StoryProgress, StoryThemeConfig } from "@/lib/storage/domain";
 import { cn } from "@/lib/style";
-import { Link } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Tooltip,
   TooltipContent,
@@ -35,10 +35,12 @@ const ActionButton = ({
   text,
   isVisible,
   actionTheme,
+  onClick,
 }: {
   text: string;
   isVisible: boolean;
   actionTheme: StoryThemeConfig["action"];
+  onClick: () => void;
 }) => {
   const [className, size] = match(actionTheme.size)
     .with("huge", () => ["py-3 px-4.5", "xl"] as const)
@@ -59,6 +61,7 @@ const ActionButton = ({
       }}
       disabled={!isVisible}
       size={size}
+      onClick={onClick}
     >
       {isVisible ? text : "????"}
     </Button>
@@ -81,6 +84,7 @@ export const SceneAction = ({
     action,
     progress,
   });
+  const navigate = useNavigate();
 
   // Only show actions that lead somewhere
   if (action.targets.length === 0) return null;
@@ -90,35 +94,39 @@ export const SceneAction = ({
   if (isTestMode) {
     return (
       <ActionTooltip isTestMode isVisible={isVisible} key={action.text}>
-        <Link
-          to="/game/test/$gameKey/$sceneKey"
-          params={{ gameKey: storyKey, sceneKey: nextScene }}
-        >
-          <ActionButton
-            text={action.text}
-            isVisible={isVisible}
-            actionTheme={actionTheme}
-          />
-        </Link>
+        <ActionButton
+          key={action.key}
+          text={action.text}
+          isVisible={isVisible}
+          actionTheme={actionTheme}
+          onClick={() =>
+            navigate({
+              to: "/game/test/$gameKey/$sceneKey",
+              params: { gameKey: storyKey, sceneKey: nextScene },
+              replace: true,
+            })
+          }
+        />
       </ActionTooltip>
     );
   }
 
   return (
     <ActionTooltip isTestMode={false} isVisible={isVisible}>
-      <Link
-        key={action.text}
-        to="/game/$gameKey/$sceneKey"
-        params={{ gameKey: storyKey, sceneKey: nextScene }}
-        search={{ storyProgressKey: progress.key }}
-        disabled={!isVisible}
-      >
-        <ActionButton
-          text={action.text}
-          isVisible={isVisible}
-          actionTheme={actionTheme}
-        />
-      </Link>
+      <ActionButton
+        key={action.key}
+        text={action.text}
+        isVisible={isVisible}
+        actionTheme={actionTheme}
+        onClick={() =>
+          navigate({
+            to: "/game/$gameKey/$sceneKey",
+            params: { gameKey: storyKey, sceneKey: nextScene },
+            search: { storyProgressKey: progress.key },
+            replace: true,
+          })
+        }
+      />
     </ActionTooltip>
   );
 };

--- a/client/src/game/components/theme-editor/theme-editor.tsx
+++ b/client/src/game/components/theme-editor/theme-editor.tsx
@@ -70,6 +70,7 @@ export const GameWithThemeEditor = ({
         isLastScene={!scene.actions.length}
         mode="theme-editor"
         theme={structuredClone(formValues)} // formValues's reference is stable, causing React Compiler to not detect theme changes
+        triggeredSideEffects={[]}
       />
       <div className="absolute top-8 right-5 flex gap-2">
         <Tooltip>

--- a/client/src/routes/game/$gameKey/$sceneKey.tsx
+++ b/client/src/routes/game/$gameKey/$sceneKey.tsx
@@ -8,6 +8,7 @@ import { getGameService } from "@/domains/game/game-service";
 import { useGetGameSceneData } from "@/game/hooks/use-get-game-scene-data";
 import { Scene } from "@/lib/storage/domain";
 
+// TODO: test life cycle
 const useGetUpdatedStoryProgress = ({ scene }: { scene?: Scene | null }) => {
   const { storyProgressKey } = Route.useSearch();
   const gameService = getGameService();

--- a/client/src/routes/game/$gameKey/$sceneKey.tsx
+++ b/client/src/routes/game/$gameKey/$sceneKey.tsx
@@ -6,39 +6,62 @@ import { z } from "zod";
 import { zodSearchValidator } from "@tanstack/router-zod-adapter";
 import { getGameService } from "@/domains/game/game-service";
 import { useGetGameSceneData } from "@/game/hooks/use-get-game-scene-data";
+import { Scene } from "@/lib/storage/domain";
+
+const useGetUpdatedStoryProgress = ({ scene }: { scene?: Scene | null }) => {
+  const { storyProgressKey } = Route.useSearch();
+  const gameService = getGameService();
+
+  const {
+    data: result,
+    isLoading,
+    isFetching,
+    isPlaceholderData,
+  } = useQuery({
+    queryFn: async () => {
+      try {
+        return await gameService.saveProgress(storyProgressKey, scene!);
+      } catch (err) {
+        console.error(err);
+        return null;
+      }
+    },
+    queryKey: ["story-progress", storyProgressKey, scene],
+    enabled: !!scene,
+    staleTime: Infinity,
+  });
+
+  return { result, isLoading: isLoading || (isFetching && isPlaceholderData) };
+};
 
 const Component = () => {
   const { sceneKey, gameKey } = Route.useParams();
-  const { storyProgressKey } = Route.useSearch();
-  const gameService = getGameService();
   const { scene, theme, isLoading } = useGetGameSceneData({
     storyKey: gameKey,
     sceneKey,
   });
 
-  const { data: storyProgress } = useQuery({
-    queryFn: async () => {
-      const progress = await gameService.saveProgress(storyProgressKey, {
-        currentSceneKey: sceneKey,
-        sceneActions: scene!.actions,
-      });
-
-      return progress;
-    },
-    queryKey: ["story-progress", storyProgressKey, sceneKey],
-    enabled: !!scene,
-  });
+  const { result: progressResult, isLoading: isProgressLoading } =
+    useGetUpdatedStoryProgress({
+      scene,
+    });
 
   if (
     isLoading ||
+    isProgressLoading ||
     scene === undefined ||
-    storyProgress === undefined ||
+    progressResult === undefined ||
     theme === undefined
   ) {
     return <BackdropLoader />;
   }
 
-  if (scene === null || storyProgress === null || theme === null) {
+  if (
+    scene === null ||
+    progressResult === null ||
+    progressResult.updatedProgress === null ||
+    theme === null
+  ) {
     console.error("Error while loading scene: ", scene);
     return <ErrorMessage />;
   }
@@ -47,7 +70,7 @@ const Component = () => {
     <GameScene
       scene={scene}
       isLastScene={!scene.actions.length}
-      progress={storyProgress}
+      progress={progressResult.updatedProgress}
       theme={theme}
       mode="game"
     />

--- a/client/src/routes/game/$gameKey/$sceneKey.tsx
+++ b/client/src/routes/game/$gameKey/$sceneKey.tsx
@@ -73,6 +73,7 @@ const Component = () => {
       progress={progressResult.updatedProgress}
       theme={theme}
       mode="game"
+      triggeredSideEffects={progressResult.effectsTriggered}
     />
   );
 };

--- a/client/src/routes/game/test/$gameKey/$sceneKey.tsx
+++ b/client/src/routes/game/test/$gameKey/$sceneKey.tsx
@@ -25,6 +25,7 @@ const Component = () => {
       isLastScene={!scene.actions.length}
       mode="test"
       theme={theme}
+      triggeredSideEffects={[]}
     />
   );
 };


### PR DESCRIPTION
On vient mettre à jour les attributs du personnage quand il y a des side effects paramétrés sur la scène. 
Dans le jeu, l'attribut est affiché en gras et l'incrément (ou décrement) est affiché. 
L'update est faite au moment de l'update de la sauvegarde pour être sûr qu'on le fait qu'une fois et au bon moment.

Close #459