### PR TITLE
feat(stats): track total play time per save (#310)

### DIFF
--- a/client/src/domains/game/__tests__/game-service.test.ts
+++ b/client/src/domains/game/__tests__/game-service.test.ts
@@ -287,6 +287,44 @@ describe("game-service", () => {
   });
   it("should not trigger side effects when revisiting the same scene consecutively", () => {});
 
+  describe("addPlayTime", () => {
+    it("should accumulate elapsed play time on the progress", async () => {
+      progressRepo.get.mockResolvedValueOnce(BASIC_STORY_PROGRESS);
+
+      const updated = await gameService.addPlayTime(
+        BASIC_STORY_PROGRESS.key,
+        4_000,
+      );
+
+      expect(progressRepo.get).toHaveBeenCalledWith(BASIC_STORY_PROGRESS.key);
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        {
+          totalPlayTimeMs: 4_000,
+        },
+      );
+      expect(updated.totalPlayTimeMs).toBe(4_000);
+    });
+
+    it("should preserve the current value before accumulating elapsed play time", async () => {
+      progressRepo.get.mockResolvedValueOnce(
+        factory.storyProgress({
+          key: BASIC_STORY_PROGRESS.key,
+          totalPlayTimeMs: 12_000,
+        }),
+      );
+
+      await gameService.addPlayTime(BASIC_STORY_PROGRESS.key, 3_000);
+
+      expect(progressRepo.update).toHaveBeenCalledWith(
+        BASIC_STORY_PROGRESS.key,
+        {
+          totalPlayTimeMs: 15_000,
+        },
+      );
+    });
+  });
+
   describe("getActionVisibility", () => {
     test("simple actions are always visible", () => {
       const isVisible = gameService.getActionVisibility({

--- a/client/src/domains/game/__tests__/library-service.test.ts
+++ b/client/src/domains/game/__tests__/library-service.test.ts
@@ -134,6 +134,7 @@ describe("library-service", () => {
       currentSceneKey: "most-recent-vroum",
       createdAt: new Date(),
       lastPlayedAt: dayjs(new Date()).add(10, "days").toDate(),
+      totalPlayTimeMs: 0,
     };
 
     const OTHER = {
@@ -144,6 +145,7 @@ describe("library-service", () => {
       currentSceneKey: "older-vroum",
       createdAt: new Date(),
       lastPlayedAt: new Date(),
+      totalPlayTimeMs: 0,
     };
 
     const FINISHED = {
@@ -154,6 +156,7 @@ describe("library-service", () => {
       currentSceneKey: "finished-vroum",
       createdAt: new Date(),
       lastPlayedAt: new Date(),
+      totalPlayTimeMs: 0,
       finished: true,
     };
 
@@ -293,6 +296,7 @@ describe("library-service", () => {
         currentSceneKey: BASIC_STORY.firstSceneKey,
         createdAt: new Date(),
         lastPlayedAt: new Date(),
+        totalPlayTimeMs: 0,
         userKey: BASIC_USER.key,
         storyKey: BASIC_STORY.key,
       });
@@ -334,6 +338,7 @@ describe("library-service", () => {
         currentSceneKey: BASIC_STORY.firstSceneKey,
         createdAt: new Date(),
         lastPlayedAt: new Date(),
+        totalPlayTimeMs: 0,
         userKey: BASIC_USER.key,
         storyKey: BASIC_STORY.key,
         character: {

--- a/client/src/domains/game/game-service.ts
+++ b/client/src/domains/game/game-service.ts
@@ -21,6 +21,10 @@ type GameServicePort = {
     updatedProgress: StoryProgress | null;
     effectsTriggered: SideEffect[];
   }>;
+  addPlayTime: (
+    storyProgressKey: string,
+    elapsedMs: number,
+  ) => Promise<StoryProgress>;
   getNextKey: (
     options: {
       sceneKey: string;
@@ -141,6 +145,25 @@ export const _getGameService = ({
         updatedProgress: { ...progress, ...updatePayload },
         effectsTriggered,
       };
+    },
+
+    addPlayTime: async (storyProgressKey, elapsedMs) => {
+      const progress = await progressRepo.get(storyProgressKey);
+
+      if (!progress)
+        throw new Error(`No progress found for story ${storyProgressKey}`);
+
+      if (elapsedMs <= 0) {
+        return progress;
+      }
+
+      const updatePayload = {
+        totalPlayTimeMs: (progress.totalPlayTimeMs ?? 0) + elapsedMs,
+      } satisfies Partial<StoryProgress>;
+
+      await progressRepo.update(progress.key, updatePayload);
+
+      return { ...progress, ...updatePayload };
     },
 
     getNextKey: (options) => {

--- a/client/src/domains/game/library-service.ts
+++ b/client/src/domains/game/library-service.ts
@@ -74,6 +74,7 @@ export const _getLibraryService = ({
       currentSceneKey: story.firstSceneKey,
       lastPlayedAt: new Date(),
       createdAt: new Date(),
+      totalPlayTimeMs: 0,
       userKey: user?.key ?? undefined,
       ...(characterConfig
         ? { character: _createInitialCharacter(characterConfig) }

--- a/client/src/game/hooks/use-track-story-play-time.ts
+++ b/client/src/game/hooks/use-track-story-play-time.ts
@@ -61,5 +61,5 @@ export const useTrackStoryPlayTime = ({
       window.removeEventListener("pagehide", handlePageHide);
       void flushTracking();
     };
-  }, [enabled, sceneKey, progressKey, flushTracking, startTracking]);
+  }, [enabled, sceneKey, progressKey]);
 };

--- a/client/src/game/hooks/use-track-story-play-time.ts
+++ b/client/src/game/hooks/use-track-story-play-time.ts
@@ -1,0 +1,65 @@
+import { getGameService } from "@/domains/game/game-service";
+import { useEffect, useEffectEvent, useRef } from "react";
+
+export const useTrackStoryPlayTime = ({
+  enabled,
+  progressKey,
+  sceneKey,
+}: {
+  enabled: boolean;
+  progressKey: string;
+  sceneKey: string;
+}) => {
+  const startedAtRef = useRef<number | null>(null);
+
+  const startTracking = useEffectEvent(() => {
+    if (!enabled || document.visibilityState !== "visible") return;
+    if (startedAtRef.current !== null) return;
+
+    startedAtRef.current = Date.now();
+  });
+
+  const flushTracking = useEffectEvent(async () => {
+    const startedAt = startedAtRef.current;
+    startedAtRef.current = null;
+
+    if (!enabled || startedAt === null) return;
+
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs <= 0) return;
+
+    try {
+      await getGameService().addPlayTime(progressKey, elapsedMs);
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    startTracking();
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        void flushTracking();
+        return;
+      }
+
+      startTracking();
+    };
+
+    const handlePageHide = () => {
+      void flushTracking();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pagehide", handlePageHide);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pagehide", handlePageHide);
+      void flushTracking();
+    };
+  }, [enabled, sceneKey, progressKey, flushTracking, startTracking]);
+};

--- a/client/src/game/hooks/use-track-story-play-time.ts
+++ b/client/src/game/hooks/use-track-story-play-time.ts
@@ -23,7 +23,7 @@ export const useTrackStoryPlayTime = ({
     const startedAt = startedAtRef.current;
     startedAtRef.current = null;
 
-    if (!enabled || startedAt === null) return;
+    if (startedAt === null) return;
 
     const elapsedMs = Date.now() - startedAt;
     if (elapsedMs <= 0) return;

--- a/client/src/game/hooks/use-track-story-play-time.ts
+++ b/client/src/game/hooks/use-track-story-play-time.ts
@@ -35,19 +35,19 @@ export const useTrackStoryPlayTime = ({
     }
   });
 
+  const handleVisibilityChange = useEffectEvent(() => {
+    if (document.visibilityState === "hidden") {
+      void flushTracking();
+      return;
+    }
+
+    startTracking();
+  });
+
   useEffect(() => {
     if (!enabled) return;
 
     startTracking();
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        void flushTracking();
-        return;
-      }
-
-      startTracking();
-    };
 
     const handlePageHide = () => {
       void flushTracking();

--- a/client/src/lib/http-client/adapters.ts
+++ b/client/src/lib/http-client/adapters.ts
@@ -118,6 +118,7 @@ const fromAPIStoryProgressAdapter = (
     ...storyProgress,
     createdAt: new Date(storyProgress.createdAt),
     lastPlayedAt: new Date(storyProgress.lastPlayedAt),
+    totalPlayTimeMs: storyProgress.totalPlayTimeMs ?? 0,
     finished: !!storyProgress.finished,
   };
 };

--- a/client/src/lib/http-client/schema.d.ts
+++ b/client/src/lib/http-client/schema.d.ts
@@ -415,6 +415,11 @@ export interface components {
              * Format: date-time
              */
             lastPlayedAt: string;
+            /**
+             * Totalplaytimems
+             * @default 0
+             */
+            totalPlayTimeMs: number;
             /** Finished */
             finished?: boolean | null;
             /** Storykey */

--- a/client/src/lib/storage/dexie/dexie-db.ts
+++ b/client/src/lib/storage/dexie/dexie-db.ts
@@ -41,7 +41,7 @@ const tables: Record<keyof Tables, string> = {
   storyThemes: "&key, &storyKey",
   characterConfigurations: "&key, &storyKey",
   storyProgresses:
-    "&key, storyKey, userKey, currentSceneKey, character, inventory, history, lastPlayedAt, createdAt",
+    "&key, storyKey, userKey, currentSceneKey, character, inventory, history, lastPlayedAt, createdAt, totalPlayTimeMs",
   wikis: "&key, userKey",
   wikiArticles: "&key, wikiKey, categoryKey, title",
   wikiCategories: "&key, wikiKey, name",
@@ -134,6 +134,27 @@ export const createDb = (
           bulkPayload.push({
             key: progress.key,
             changes: { createdAt: progress.lastPlayedAt ?? new Date() },
+          });
+        }
+      });
+
+      if (bulkPayload.length) {
+        await db.storyProgresses.bulkUpdate(bulkPayload);
+      }
+    });
+
+  // Migration: add total play time to story progresses
+  db.version(11)
+    .stores(tables)
+    .upgrade(async () => {
+      const bulkPayload: { key: string; changes: Partial<StoryProgress> }[] =
+        [];
+
+      await db.storyProgresses.each((progress) => {
+        if (typeof progress.totalPlayTimeMs !== "number") {
+          bulkPayload.push({
+            key: progress.key,
+            changes: { totalPlayTimeMs: 0 },
           });
         }
       });

--- a/client/src/lib/storage/domain.ts
+++ b/client/src/lib/storage/domain.ts
@@ -195,6 +195,7 @@ export type StoryProgress = {
   inventory?: Record<string, unknown>;
   createdAt: Date;
   lastPlayedAt: Date;
+  totalPlayTimeMs: number;
   finished?: boolean;
 };
 

--- a/client/src/lib/testing/factory.ts
+++ b/client/src/lib/testing/factory.ts
@@ -236,6 +236,7 @@ const _storyProgressFactory = {
   history: () => Array.from(Array(5), nanoid),
   createdAt: faker.date.anytime,
   lastPlayedAt: faker.date.anytime,
+  totalPlayTimeMs: () => faker.number.int({ min: 0 }),
   storyKey: nanoid,
   userKey: nanoid,
   finished: () => Math.random() > 0.5,

--- a/client/src/repositories/stubs/data.ts
+++ b/client/src/repositories/stubs/data.ts
@@ -80,4 +80,5 @@ export const BASIC_STORY_PROGRESS: StoryProgress = {
   currentSceneKey: "vroum",
   createdAt: new Date(),
   lastPlayedAt: new Date(),
+  totalPlayTimeMs: 0,
 };

--- a/client/src/routes/game/$gameKey/$sceneKey.tsx
+++ b/client/src/routes/game/$gameKey/$sceneKey.tsx
@@ -7,6 +7,7 @@ import { zodSearchValidator } from "@tanstack/router-zod-adapter";
 import { getGameService } from "@/domains/game/game-service";
 import { useGetGameSceneData } from "@/game/hooks/use-get-game-scene-data";
 import { Scene } from "@/lib/storage/domain";
+import { useTrackStoryPlayTime } from "@/game/hooks/use-track-story-play-time";
 
 // TODO: test life cycle
 const useGetUpdatedStoryProgress = ({ scene }: { scene?: Scene | null }) => {
@@ -37,6 +38,7 @@ const useGetUpdatedStoryProgress = ({ scene }: { scene?: Scene | null }) => {
 
 const Component = () => {
   const { sceneKey, gameKey } = Route.useParams();
+  const { storyProgressKey } = Route.useSearch();
   const { scene, theme, isLoading } = useGetGameSceneData({
     storyKey: gameKey,
     sceneKey,
@@ -46,6 +48,12 @@ const Component = () => {
     useGetUpdatedStoryProgress({
       scene,
     });
+
+  useTrackStoryPlayTime({
+    enabled: !!scene && !!progressResult?.updatedProgress,
+    progressKey: storyProgressKey,
+    sceneKey,
+  });
 
   if (
     isLoading ||

--- a/server/app/domains/synchronization/repositories/adapters.py
+++ b/server/app/domains/synchronization/repositories/adapters.py
@@ -166,6 +166,7 @@ def make_mongo_story_progress(
         currentSceneKey=domain.current_scene_key,
         createdAt=domain.created_at,
         lastPlayedAt=domain.last_played_at,
+        totalPlayTimeMs=domain.total_play_time_ms,
         finished=domain.finished,
         storyKey=domain.story_key,
         lastSyncAt=domain.last_sync_at,
@@ -278,6 +279,7 @@ def make_synchronization_story_progress(
         current_scene_key=story_progress["currentSceneKey"],
         created_at=story_progress["lastPlayedAt"],
         last_played_at=story_progress["lastPlayedAt"],
+        total_play_time_ms=story_progress.get("totalPlayTimeMs", 0),
         finished=story_progress.get("finished"),
         last_sync_at=story_progress.get("lastSyncAt"),
     )

--- a/server/app/domains/synchronization/type_defs.py
+++ b/server/app/domains/synchronization/type_defs.py
@@ -90,6 +90,7 @@ class SynchronizationStoryProgress(BaseModel):
     current_scene_key: str
     created_at: datetime
     last_played_at: datetime
+    total_play_time_ms: int = 0
     finished: bool | None = None
     story_key: str
     last_sync_at: datetime | None = None

--- a/server/app/endpoints/synchronization/type_defs.py
+++ b/server/app/endpoints/synchronization/type_defs.py
@@ -282,6 +282,7 @@ class StoryProgress(BaseAPIModel):
     current_scene_key: str
     created_at: datetime
     last_played_at: datetime
+    total_play_time_ms: int = 0
     finished: bool | None = None
     story_key: str
     last_sync_at: datetime | None = None
@@ -295,6 +296,7 @@ class StoryProgress(BaseAPIModel):
             current_scene_key=domain.current_scene_key,
             created_at=domain.created_at,
             last_played_at=domain.last_played_at,
+            total_play_time_ms=domain.total_play_time_ms,
             finished=domain.finished,
             story_key=domain.story_key,
             last_sync_at=domain.last_sync_at,
@@ -308,6 +310,7 @@ class StoryProgress(BaseAPIModel):
             current_scene_key=self.current_scene_key,
             created_at=self.created_at,
             last_played_at=self.last_played_at,
+            total_play_time_ms=self.total_play_time_ms,
             finished=self.finished,
             story_key=self.story_key,
             last_sync_at=self.last_sync_at,

--- a/server/app/utils/mongo/base_repository.py
+++ b/server/app/utils/mongo/base_repository.py
@@ -103,6 +103,7 @@ class MongoStoryProgress(WithId):
     currentSceneKey: str
     createdAt: datetime
     lastPlayedAt: datetime
+    totalPlayTimeMs: NotRequired[int]
     finished: bool | None
     storyKey: str
     lastSyncAt: datetime | None


### PR DESCRIPTION
## Résumé
Ajoute le suivi du temps de jeu total pour chaque sauvegarde d'histoire.

## Modifications
- ajout de `totalPlayTimeMs` dans `StoryProgress`
- initialisation du champ à `0` pour les nouvelles sauvegardes et migration des sauvegardes locales existantes
- comptage du temps uniquement lorsque l'onglet du jeu est visible
- flush du temps accumulé lors du masquage de l'onglet, de la fermeture de la page et du changement de scène
- conservation du comportement actuel de `lastPlayedAt`
- propagation du nouveau champ dans la synchronisation client/serveur et régénération du schéma OpenAPI côté client
