### PR TITLE
505 form edition responsive

### DIFF
--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-content-form.tsx
@@ -69,7 +69,7 @@ const SceneContentForm = ({ scene }: { scene: Scene }) => {
                     onSerializedChange={field.onChange}
                     initialState={scene.content}
                     editable
-                    className="h-75 max-w-112.5"
+                    className="h-75 w-full"
                     toolbarPlugins={[
                       <WikiPlugin wikiKey={story.wikiKey ?? null} />,
                     ]}

--- a/client/src/builder/components/builder-editor-bar/scene-editor/scene-editor.tsx
+++ b/client/src/builder/components/builder-editor-bar/scene-editor/scene-editor.tsx
@@ -26,7 +26,7 @@ export const SceneEditor = ({ sceneKey }: { sceneKey: string }) => {
   const openDeleteConfirm = useDeleteSceneStore((state) => state.open);
 
   return (
-    <Toolbar className="w-125" id="scene-editor">
+    <Toolbar className="w-[min(500px,calc(100vw-2.5rem))]" id="scene-editor">
       <ToolbarHeader className="flex-row items-center justify-between">
         <ToolbarTitle>Edit scene</ToolbarTitle>
         {!isFirstScene && (

--- a/client/src/builder/components/builder-editor-bar/story-editor/story-editor.tsx
+++ b/client/src/builder/components/builder-editor-bar/story-editor/story-editor.tsx
@@ -19,7 +19,7 @@ export const StoryEditor = () => {
   const { deleteStory } = useDeleteStory();
 
   return (
-    <Toolbar className="w-100">
+    <Toolbar className="w-[min(400px,calc(100vw-2.5rem))]">
       <ToolbarHeader className="flex-row items-center justify-between">
         <ToolbarTitle>Edit story</ToolbarTitle>
         <DeleteStoryModal

--- a/client/src/design-system/components/editor/components/content-editable.tsx
+++ b/client/src/design-system/components/editor/components/content-editable.tsx
@@ -22,7 +22,7 @@ export const ContentEditable = ({
     <LexicalContentEditable
       ref={contentEditableRef}
       className={cn(
-        "relative block min-h-full py-4 focus:outline-none",
+        "relative block min-h-full py-4 break-words focus:outline-none",
         className,
       )}
       style={{ color: textColor }}

--- a/client/src/design-system/components/editor/components/rich-text-editor.tsx
+++ b/client/src/design-system/components/editor/components/rich-text-editor.tsx
@@ -42,6 +42,7 @@ export const RichText = ({
     <div
       id="rich-text-editor"
       className={cn(
+        "w-full min-w-0 overflow-hidden",
         editable && "bg-background min-h-25 rounded-lg border",
         "focus-within:border-ring focus-within:ring-ring/10 focus-within:ring-[3px]", // The focus style is the same as the input's & textarea's
         // TODO: handle error state like other inputs

--- a/client/src/design-system/components/editor/plugins/base-plugins.tsx
+++ b/client/src/design-system/components/editor/plugins/base-plugins.tsx
@@ -67,7 +67,10 @@ export const BasePlugins = ({
       contentEditable={
         <RichTextContainer
           textDisplayMode={textDisplayMode}
-          className={cn("relative my-0.5 mr-0.5", className)}
+          className={cn(
+            "relative my-0.5 mr-0.5 w-full overflow-hidden",
+            className,
+          )}
           onClick={() => {
             contentEditableRef.current?.focus();
           }}

--- a/client/src/design-system/components/editor/plugins/editor-plugins.tsx
+++ b/client/src/design-system/components/editor/plugins/editor-plugins.tsx
@@ -12,7 +12,7 @@ export const EditorPlugins = ({
 }) => {
   return (
     <>
-      <div className="vertical-align-middle border-tl sticky top-0 z-10 flex items-center gap-1 overflow-auto rounded-t-lg border-b bg-white p-1">
+      <div className="vertical-align-middle border-tl sticky top-0 z-10 flex w-full min-w-0 items-center gap-1 overflow-x-auto rounded-t-lg border-b bg-white p-1 [&>*]:shrink-0">
         <FontFormatToolbarPlugin format="bold" />
         <FontFormatToolbarPlugin format="italic" />
         <FontFormatToolbarPlugin format="underline" />


### PR DESCRIPTION
## Résumé
- Rendre le `SceneEditor` et le `StoryEditor` responsives sur mobile
- Fix du débordement de la toolbar du rich text editor et du contenu sur petit écran

## Changements
- `SceneEditor` passé de `w-125` (500px fixe) à `w-[min(500px,calc(100vw-2.5rem))]` : garde 500px sur desktop, s'adapte à l'écran sur mobile
- `StoryEditor` passé de `w-100` (400px fixe) à `w-[min(400px,calc(100vw-2.5rem))]` : même principe
- `RichText` (rich text editor) : ajout `w-full min-w-0 overflow-hidden` sur le wrapper pour empêcher le contenu de déborder
- `RichTextContainer` (BasePlugins) : ajout `w-full overflow-hidden` pour contraindre le ScrollArea
- `ContentEditable` : ajout `break-words` pour wrapper les longs mots
- `EditorPlugins` (toolbar des boutons B/I/U/etc) : ajout `w-full min-w-0` + `[&>*]:shrink-0` pour scroll horizontal sur mobile
- `SceneContentForm` : `max-w-112.5` remplacé par `w-full` (la contrainte de largeur vient maintenant du parent)

## Parti pris
J'ai utilisé `min(Xpx, 100vw-2.5rem)` pour garder une largeur fixe sur desktop tout en s'adaptant sur mobile, avec une marge de 40px (2.5rem) qui correspond au positionnement `right-5` du builder. Le rich text editor contraint maintenant sa largeur via une chaîne de `w-full min-w-0 overflow-hidden` sur les conteneurs imbriqués pour que le contenu et la toolbar restent dans les bornes du parent quelle que soit la taille de l'écran.

NB: j'ai oublie de checkout sur dev j'ai checkout depuis la branche 476 d'ou les suppression ...

Closes #505