### PR TITLE
:sparkles: Allow renaming story on import

### DIFF
--- a/client/src/design-system/components/import-modal.tsx
+++ b/client/src/design-system/components/import-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  Input,
 } from "@/design-system/primitives";
 import { ANONYMOUS_AUTHOR } from "@/services/common/import-export-service";
 import { ReactNode, useState } from "react";
@@ -16,8 +17,12 @@ import { JsonStoryData } from "@/services/common/schema";
 
 const ImportPreview = ({
   storyFromImport,
+  title,
+  onTitleChange,
 }: {
   storyFromImport: JsonStoryData;
+  title: string;
+  onTitleChange: (title: string) => void;
 }) => {
   return (
     <div className="flex flex-col gap-1">
@@ -27,9 +32,13 @@ const ImportPreview = ({
           src={storyFromImport.story.image}
           className="block h-20 w-20 object-cover"
         />
-        <div>
-          <p className="font-semibold">{storyFromImport.story.title}</p>
-          <p>
+        <div className="flex-1">
+          <Input
+            value={title}
+            onChange={(e) => onTitleChange(e.target.value)}
+            className="font-semibold"
+          />
+          <p className="mt-1">
             Written by{" "}
             {storyFromImport.story.author?.username ??
               ANONYMOUS_AUTHOR.username}
@@ -61,13 +70,19 @@ export const ImportModal = ({
   const [storyFromImport, setStoryFromImport] = useState<JsonStoryData | null>(
     null,
   );
+  const [title, setTitle] = useState("");
+
+  const reset = () => {
+    setStoryFromImport(null);
+    setTitle("");
+  };
 
   return (
     <Dialog
       open={isModalOpen}
       onOpenChange={(open) => {
         setIsModalOpen(open);
-        if (!open) setStoryFromImport(null);
+        if (!open) reset();
       }}
     >
       <DialogTrigger asChild>{trigger}</DialogTrigger>
@@ -78,14 +93,22 @@ export const ImportModal = ({
           </DialogTitle>
         </DialogHeader>
         {storyFromImport ? (
-          <ImportPreview storyFromImport={storyFromImport} />
+          <ImportPreview
+            storyFromImport={storyFromImport}
+            title={title}
+            onTitleChange={setTitle}
+          />
         ) : (
           <FileDropInput
             accept="json"
             readAs="text"
             onUploadFile={(content) => {
               // TODO: test what happens when parsing fails
-              if (content) setStoryFromImport(parseFile(content));
+              if (content) {
+                const parsed = parseFile(content);
+                setStoryFromImport(parsed);
+                if (parsed) setTitle(parsed.story.title);
+              }
             }}
           />
         )}
@@ -94,17 +117,20 @@ export const ImportModal = ({
             variant="secondary"
             onClick={() => {
               setIsModalOpen(false);
-              setStoryFromImport(null);
+              reset();
             }}
           >
             Cancel
           </Button>
 
           <Button
-            disabled={!storyFromImport}
+            disabled={!storyFromImport || !title.trim()}
             onClick={() => {
               setIsModalOpen(false);
-              onImportStory(storyFromImport!);
+              onImportStory({
+                ...storyFromImport!,
+                story: { ...storyFromImport!.story, title: title.trim() },
+              });
             }}
           >
             Import


### PR DESCRIPTION
## Résumé
- Permettre de renommer une histoire au moment de l'import (titre éditable dans la modale d'import)

## Changements
- `ImportPreview` : remplacement du `<p>` du titre par un `<Input>` éditable, pré-rempli avec le titre du JSON
- `ImportModal` : ajout d'un state `title` qui suit la valeur de l'input. Au click sur "Import", on override le title du payload avec la valeur saisie. Le bouton Import est désactivé si le titre est vide.

## Parti pris
J'ai mis l'input directement dans le preview de la modale plutôt que de faire un écran séparé : l'utilisateur voit immédiatement le titre actuel du JSON et peut le modifier avant d'importer. Le reste de la preview (auteur, genres, nombre de scènes) reste affiché autour pour le contexte.

Closes #476