### PR TITLE
Fix nodes size in Builder

### DIFF
--- a/client/src/builder/components/nodes/index.ts
+++ b/client/src/builder/components/nodes/index.ts
@@ -1,0 +1,6 @@
+export const NODE_WIDTH = Number.parseFloat(
+  window
+    .getComputedStyle(document.body)
+    .getPropertyValue("--node-width")
+    .replace("px", ""),
+);

--- a/client/src/builder/components/nodes/scene/scene.tsx
+++ b/client/src/builder/components/nodes/scene/scene.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/design-system/primitives/card";
 import { Handle, NodeProps, Position } from "@xyflow/react";
 import { EditIcon } from "lucide-react";
-import { BuilderNode, NODE_WIDTH } from "../../../types";
+import { BuilderNode } from "../../../types";
 import { cn } from "@/lib/style";
 import { Button } from "@/design-system/primitives";
 import { useBuilderEditorStore } from "@/builder/hooks/use-builder-editor-store";
@@ -39,7 +39,7 @@ export const SceneNode = ({ data, selected }: SceneNodeProps) => {
   return (
     <Card
       className={cn(
-        `group w-[${NODE_WIDTH}px] relative`,
+        `group relative w-(--node-width)`,
         isFirstScene && "bg-primary/60",
         selected && "ring-black",
       )}

--- a/client/src/builder/hooks/use-builder-edges.tsx
+++ b/client/src/builder/hooks/use-builder-edges.tsx
@@ -1,5 +1,5 @@
 import { Connection, FinalConnectionState, useReactFlow } from "@xyflow/react";
-import { BuilderEdge, BuilderNode, NODE_WIDTH } from "../types";
+import { BuilderEdge, BuilderNode } from "../types";
 import { useErrorToast } from "./use-error-toast";
 import { DEFAULT_SCENE, useAddScene } from "./use-add-scene";
 import { useBuilderContext } from "./use-builder-context";
@@ -12,6 +12,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { makeGetSceneQueryOptions } from "./use-get-scene";
 import { useHandleActionTargetsError } from "./use-handle-action-targets-error";
+import { NODE_WIDTH } from "../components/nodes";
 
 // TODO: test this
 export const useBuilderEdges = () => {

--- a/client/src/builder/types.ts
+++ b/client/src/builder/types.ts
@@ -8,8 +8,6 @@ export type SceneProps = Scene & {
   isEditable?: boolean;
 };
 
-export const NODE_WIDTH = 300;
-
 export type BuilderNode = Node<SceneProps, "scene">;
 
 // EDGES

--- a/client/src/domains/builder/layout-service.ts
+++ b/client/src/domains/builder/layout-service.ts
@@ -1,6 +1,7 @@
-import { BuilderNode, BuilderEdge, NODE_WIDTH } from "@/builder/types";
+import { BuilderNode, BuilderEdge } from "@/builder/types";
 import ELK from "elkjs/lib/elk.bundled.js";
 import { LayoutServicePort } from "./ports/layout-service-port";
+import { NODE_WIDTH } from "@/builder/components/nodes";
 
 // TODO: find a way to test this without ELK time out
 const _getLayoutService = (): LayoutServicePort => {

--- a/client/src/globals.css
+++ b/client/src/globals.css
@@ -62,6 +62,7 @@
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
 
   --navbar-height: 50px;
+  --node-width: 300px;
 }
 
 .dark {


### PR DESCRIPTION
On passait une variable à tw, qu'il ne sait pas interpoler au runTime, donc je passe plutôt par une variable CSS + un helper qui vient lire dynamiquement le CSS calculé du DOM pour rendre la valeur accessible dans du code JS. 

Close #578 