### PR TITLE
Fix wiki link editior in rich text

### DIFF
--- a/client/src/builder/components/lexical-node-wiki-article-editor.tsx
+++ b/client/src/builder/components/lexical-node-wiki-article-editor.tsx
@@ -10,6 +10,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogFooter,
   DialogTitle,
   DialogTrigger,
   Form,
@@ -74,9 +75,11 @@ const useEditWikiNodeActions = ({ node }: { node: WikiNode }) => {
 const EditWikiNodeForm = ({
   node,
   articleKey,
+  onSubmit,
 }: {
   node: WikiNode;
   articleKey?: string;
+  onSubmit: () => void;
 }) => {
   const form = useForm<EditLinkPayload>({
     resolver: zodResolver(editLinkSchema),
@@ -100,7 +103,13 @@ const EditWikiNodeForm = ({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(editWikiNode)} className="space-y-4">
+      <form
+        onSubmit={form.handleSubmit((d) => {
+          editWikiNode(d);
+          onSubmit();
+        })}
+        className="space-y-4"
+      >
         <FormField
           control={form.control}
           name="text"
@@ -179,12 +188,14 @@ const EditWikiNodeForm = ({
             </FormItem>
           )}
         />
-        <DialogClose className="flex w-full justify-end gap-2" asChild>
-          <div>
-            <Button variant="secondary">Cancel</Button>
-            <Button type="submit">Save</Button>
-          </div>
-        </DialogClose>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="secondary" type="button">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit">Save</Button>
+        </DialogFooter>
       </form>
     </Form>
   );
@@ -203,6 +214,7 @@ const ArticleInfo = ({
     enabled: !!articleKey,
   });
   const { deleteWikiNode } = useEditWikiNodeActions({ node });
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
   return (
     <PopoverContent>
@@ -212,7 +224,7 @@ const ArticleInfo = ({
         </span>
         <div className="flex">
           {isLoading || !article || !articleKey ? null : (
-            <Dialog>
+            <Dialog onOpenChange={setIsEditDialogOpen} open={isEditDialogOpen}>
               <DialogTrigger asChild>
                 <Button size="xs" variant="ghost" disabled={!article}>
                   <EditIcon />
@@ -221,7 +233,13 @@ const ArticleInfo = ({
               <DialogContent>
                 <DialogTitle>Edit Article Link</DialogTitle>
                 <div className="mt-2">
-                  <EditWikiNodeForm node={node} articleKey={articleKey} />
+                  <EditWikiNodeForm
+                    node={node}
+                    articleKey={articleKey}
+                    onSubmit={() => {
+                      setIsEditDialogOpen(false);
+                    }}
+                  />
                 </div>
               </DialogContent>
             </Dialog>


### PR DESCRIPTION
Le bouton _submit_ était wrappé dans une dialogClose qui ferme la modale avant que le form ne soit submit, ce qui annule la soumission du form

Close #587 