### PR TITLE
Fix tooltip on disabled actions

### DIFF
--- a/client/src/game/components/scene-action.tsx
+++ b/client/src/game/components/scene-action.tsx
@@ -18,7 +18,9 @@ const ActionTooltip = ({
 }: PropsWithChildren<{ isVisible: boolean; isTestMode: boolean }>) => {
   return (
     <Tooltip open={isVisible ? false : undefined}>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipTrigger asChild>
+        <div>{children}</div>
+      </TooltipTrigger>
       <TooltipContent className="max-w-75 text-xs">
         You did not unlock this choice...
         {isTestMode && (


### PR DESCRIPTION
apparemment les boutons disabled ne trigger pas d'event donc le tooltip était pas activé
super intéressant